### PR TITLE
Vautour theme: corrected a problem with ajax search on page that use "frame.html?link=...."

### DIFF
--- a/root/thruk/themes/Vautour/templates/side.tt
+++ b/root/thruk/themes/Vautour/templates/side.tt
@@ -9,6 +9,12 @@
     <link href="[% url_prefix %]thruk/themes/[% theme %]/stylesheets/thruk.css" type="text/css" rel="stylesheet" />
     <link rel="shortcut icon" href="[% url_prefix %]thruk/themes/[% theme %]/images/favicon.ico" type="image/ico" />
     <script type="text/javascript" src="[% url_prefix %]thruk/javascript/prototype-1.6.1.js"></script>
+    <script type="text/javascript">
+    <!--
+    var theme      = '[% theme %]';
+    var url_prefix = '[% url_prefix %]';
+    -->
+    </script>
     <script type="text/javascript" src="[% url_prefix %]thruk/javascript/thruk.js"></script>
     [% PROCESS extra_headers.tt %]
   </head>


### PR DESCRIPTION
Hi Sven,

I did not send you something since a long time !
We are using a lot Thruk at work and I have again some time to contribute (a little ;-) ).

I found missing declaration of url_prefix js variable in file side.tt but the one for Vautour theme. That caused the ajax search bar to not propose search result during typing. This problem is appearing only when we are on page accessed using link "frame.html?link=/some/thing.html".

I'm not using frames (use_frames = 0), it seems Thruk is not using all the time the file side.tt from theme and instead switch to the global one in (templates/side.tt). If I compare generated code for URLs "/thruk/cgi-bin/tac.cgi" and another one "/thruk/frame.html?link=...", I can see that it was not the same headers (missing the <script></script> section I added in commit).

Hope that it can help ;-)
Bye, Vincent.
