### PR TITLE
Sticky ack is always true for commands 33 / 34

### DIFF
--- a/templates/cmd/cmd_typ_33.tt
+++ b/templates/cmd/cmd_typ_33.tt
@@ -18,12 +18,11 @@
     [% comment_data         = c.request.parameters.com_data %]
     [% host_name            = c.request.parameters.host %]
     [% comment_author       = c.request.parameters.com_author %]
-    [% IF c.request.parameters.sticky_ack %][% options = 2 %][% ELSE %][% options = 1 %][% END %]
 
     [% IF has_expire_acks && end_time_unix > 0 && c.request.parameters.use_expire %]
-    ACKNOWLEDGE_HOST_PROBLEM_EXPIRE;[% sprintf("%s;%d;%d;%d;%d;%s;%s",host_name,options,send_notification,persistent_comment,end_time_unix,comment_author,comment_data) %]
+    ACKNOWLEDGE_HOST_PROBLEM_EXPIRE;[% sprintf("%s;%d;%d;%d;%d;%s;%s",host_name,sticky_ack,send_notification,persistent_comment,end_time_unix,comment_author,comment_data) %]
     [% ELSE %]
-    ACKNOWLEDGE_HOST_PROBLEM;[% sprintf("%s;%d;%d;%d;%s;%s",host_name,options,send_notification,persistent_comment,comment_author,comment_data) %]
+    ACKNOWLEDGE_HOST_PROBLEM;[% sprintf("%s;%d;%d;%d;%s;%s",host_name,sticky_ack,send_notification,persistent_comment,comment_author,comment_data) %]
     [% END %]
 [% END %]
 

--- a/templates/cmd/cmd_typ_34.tt
+++ b/templates/cmd/cmd_typ_34.tt
@@ -19,12 +19,11 @@
     [% service_desc         = c.request.parameters.service %]
     [% host_name            = c.request.parameters.host %]
     [% comment_author       = c.request.parameters.com_author %]
-    [% IF c.request.parameters.sticky_ack %][% options = 2 %][% ELSE %][% options = 1 %][% END %]
 
     [% IF has_expire_acks && end_time_unix > 0 && c.request.parameters.use_expire %]
-    ACKNOWLEDGE_SVC_PROBLEM_EXPIRE;[% sprintf("%s;%s;%d;%d;%d;%d;%s;%s",host_name,service_desc,options,send_notification,persistent_comment,end_time_unix,comment_author,comment_data) %]
+    ACKNOWLEDGE_SVC_PROBLEM_EXPIRE;[% sprintf("%s;%s;%d;%d;%d;%d;%s;%s",host_name,service_desc,sticky_ack,send_notification,persistent_comment,end_time_unix,comment_author,comment_data) %]
     [% ELSE %]
-    ACKNOWLEDGE_SVC_PROBLEM;[% sprintf("%s;%s;%d;%d;%d;%s;%s",host_name,service_desc,options,send_notification,persistent_comment,comment_author,comment_data) %]
+    ACKNOWLEDGE_SVC_PROBLEM;[% sprintf("%s;%s;%d;%d;%d;%s;%s",host_name,service_desc,sticky_ack,send_notification,persistent_comment,comment_author,comment_data) %]
     [% END %]
 [% END %]
 


### PR DESCRIPTION
Hello Sven,
I encountered a problem with the acknowledgement commands and the sticky option. This one was always true whatever if checkbox was selected or not... Please have a look at this pull request ;-)

I renamed a variable called "options" to use "sticky_ack" instead that you define earlier if the parameter is found in the request.

Bye,
Vinz
