### PR TITLE
hallo sven!

### DIFF
--- a/lib/Thruk/Utils.pm
+++ b/lib/Thruk/Utils.pm
@@ -559,7 +559,11 @@ sub version_compare {
         next if !defined $v2[$x];
         my $cmp = 0;
         if($v2[$x] =~ m/^(\d+)/gmx) { $cmp = $1; }
-        return 0 unless $v1[$x] <= $cmp;
+        if ($v1[$x] <= $cmp) {
+            return 1;
+        } else {
+            return 0;
+        }
     }
     return 1;
 }


### PR DESCRIPTION
ich denke der versionsvergleich ist falsch.

[WARN][Thruk.Backend.Provider.Livestatus] backend 'External Shinken' uses too old livestatus version: '2.0-shinken', minimum requirement is at least '1.1.3'. Upgrade if you experience problems.

anbei der fix.

gruss birger
