### PR TITLE
Remove a livestatus query

### DIFF
--- a/lib/Thruk/Backend/Provider/Livestatus.pm
+++ b/lib/Thruk/Backend/Provider/Livestatus.pm
@@ -267,7 +267,7 @@ sub get_hosts_by_servicequery {
     my($self, %options) = @_;
 
     $options{'columns'} = [qw/
-        host_has_been_checked host_name host_state host_scheduled_downtime_depth host_acknowledged
+        host_has_been_checked host_name host_state host_scheduled_downtime_depth host_acknowledged has_been_checked state
         /];
 
     my $data = $self->_get_table('services', \%options);

--- a/lib/Thruk/Utils/Status.pm
+++ b/lib/Thruk/Utils/Status.pm
@@ -423,6 +423,7 @@ sub fill_totals_box {
 
     # host status box
     my $host_stats = {};
+    my $service_stats = {};
     if(   defined $c->stash->{style} and $c->stash->{style} eq 'detail'
        or ( $c->stash->{'servicegroup'}
             and ( $c->stash->{style} eq 'overview' or $c->stash->{style} eq 'grid' or $c->stash->{style} eq 'summary' )
@@ -440,6 +441,15 @@ sub fill_totals_box {
         };
         my %hosts;
         for my $service (@{$services}) {
+ 	    if($service->{'has_been_checked'} == 1) {
+		    $service_stats->{'ok'}++        if $service->{'state'} == 0;
+		    $service_stats->{'warning'}++   if $service->{'state'} == 1;
+		    $service_stats->{'critical'}++  if $service->{'state'} == 2;
+		    $service_stats->{'unknown'}++   if $service->{'state'} == 3;
+	    }
+ 	    if($service->{'has_been_checked'} == 0) {
+		    $service_stats->{'pending'}++;
+	    }
             next if defined $hosts{$service->{'host_name'}};
             $hosts{$service->{'host_name'}} = 1;
 
@@ -456,11 +466,12 @@ sub fill_totals_box {
         }
     } else {
         $host_stats = $c->{'db'}->get_host_stats( filter => [ Thruk::Utils::Auth::get_auth_filter( $c, 'hosts' ), $hostfilter ] );
+        $service_stats = $c->{'db'}->get_service_stats( filter => [ Thruk::Utils::Auth::get_auth_filter( $c, 'services' ), $servicefilter ] );
     }
     $c->stash->{'host_stats'} = $host_stats;
 
     # services status box
-    $c->stash->{'service_stats'} = $c->{'db'}->get_service_stats( filter => [ Thruk::Utils::Auth::get_auth_filter( $c, 'services' ), $servicefilter ] );
+    $c->stash->{'service_stats'} = $service_stats;
 
     # set audio file to play
     Thruk::Utils::Status::set_audio_file($c);


### PR DESCRIPTION
This patch compute data for services summary using data of a previous livestatus query instead of running a new querie.

I'm using a shinken instance with 24k services and 2.8k hosts to benchmark this url : "http://localhost:3000/thruk/cgi-bin/status.cgi?host=all&servicestatustypes=28"

ab -n 10 -c 1 goes from 3.8s (mean time) per request down to 2.5s
