### PR TITLE
use_ssl_authentication=1 shows full DN instead of CN

### DIFF
--- a/lib/Catalyst/Authentication/Credential/Thruk.pm
+++ b/lib/Catalyst/Authentication/Credential/Thruk.pm
@@ -96,14 +96,12 @@ sub authenticate {
     my $authenticated = 0;
 
     # authenticated by ssl
-    if(defined $c->config->{'cgi_cfg'}->{'use_ssl_authentication'} and $c->config->{'cgi_cfg'}->{'use_ssl_authentication'} >= 1) {
-        if(defined $c->engine->env->{'SSL_CLIENT_S_DN_CN'}) {
+    if(defined $c->config->{'cgi_cfg'}->{'use_ssl_authentication'} and $c->config->{'cgi_cfg'}->{'use_ssl_authentication'} >= 1
+        and defined $c->engine->env->{'SSL_CLIENT_S_DN_CN'}) {
             $username = $c->engine->env->{'SSL_CLIENT_S_DN_CN'};
-        }
     }
-
     # from cli
-    if(defined $c->stash->{'remote_user'} and $c->stash->{'remote_user'} ne '?') {
+    elsif(defined $c->stash->{'remote_user'} and $c->stash->{'remote_user'} ne '?') {
         $username = $c->stash->{'remote_user'};
     }
     # basic authentication


### PR DESCRIPTION
Hi,
use_ssl_authentication=1 wasn't working properly for me. It kept displaying the full SSL Subject DN instead of the CN.

With the minor changes it now shows the CN (user's name in our case) in the thruk GUI.

Thanks,
Mark Clarkson
