### PR TITLE
--community abc\!cde

### DIFF
--- a/lib/Thruk/Backend/Manager.pm
+++ b/lib/Thruk/Backend/Manager.pm
@@ -497,7 +497,7 @@ sub expand_command {
         $command_name = $vars->{$source} || '';
     }
 
-    my($name, @com_args) = split(/!/mx, $command_name, 255);
+    my($name, @com_args) = split(/(?<!\\)!/mx, $command_name, 255);
 
     # it is possible to define hosts without a command
     if(!defined $name or $name =~ m/^\s*$/mx) {


### PR DESCRIPTION
Servus,

mit dem Patch zerschiesst es das Expanded Command unten im Service Detail nicht, wenn ein Ausrufezeichen in einem Argument vorhanden ist.

Gruss,
Gerhard
