### PR TITLE
Increase verbosity of "not readable" error message

### DIFF
--- a/lib/Thruk/Utils.pm
+++ b/lib/Thruk/Utils.pm
@@ -203,7 +203,7 @@ sub read_cgi_cfg {
             $c->error("cgi.cfg not readable: ".$!);
             return $c->detach('/error/index/4');
         }
-        print STDERR "$file not readable: ".$!."\n\n";
+        print STDERR "$config->{'project_root'}/$file not readable: ".$!."\n\n";
         return;
     }
 


### PR DESCRIPTION
While setting up Thruk, I got an error message saying "cgi.cfg not readable", whereas the file was there (as "ssi/cgi.cfg") and perfectly readable.
I changed the error message to make sure the script was effectively trying to read "ssi/cgi.cfg", but it turned out that it was looking for "cgi.cfg" one level higher (Adding a symlink fixed it !)
