### PR TITLE
Quotes in action_url for graphite #154

### DIFF
--- a/docs/THRUK_MANUAL.html
+++ b/docs/THRUK_MANUAL.html
@@ -17801,7 +17801,9 @@ in this url.</p></div>
     check_command         check_load
   }</tt></pre>
 </div></div>
-<div class="paragraph"><p>ex.:</p></div>
+<div class="paragraph">Info : Quotes are supported in the action_url statement, you may want to use it for special graphite function (<a href="http://graphite.readthedocs.org/en/1.0/functions.html"> see documentation </a>). 
+Do not escape double quotes here, otherwise graph won't work.
+<p>ex.:</p></div>
 <div class="literalblock">
 <div class="content">
 <pre><tt>graph_word = /pnp4nagios/   # for pnp4nagios

--- a/docs/THRUK_MANUAL.txt
+++ b/docs/THRUK_MANUAL.txt
@@ -1467,6 +1467,9 @@ ex.:
   graph_word = /render/       # for graphite
 
 
+Info : Quotes are supported in the action_url statement, you may want to use it for special graphite function (http://graphite.readthedocs.org/en/1.0/functions.html)
+Do not escape double quotes here, otherwise graph won't work.
+
 ==== show_custom_vars
 Show custom vars in host / service ext info. List variable names to
 display in the host and service extinfo details page. Can be specified

--- a/templates/_perfdata_table.tt
+++ b/templates/_perfdata_table.tt
@@ -7,7 +7,7 @@ var pnp_url = "";
 [% END +%]
 var graph_url = "";
 [%+ IF graph_url %]
-var graph_url = "[% graph_url %]";
+var graph_url = "[% escape_quotes(graph_url) %]";
 [% END +%]
 var data = [% json_encode(plugin_output, perfdata, check_command) %];
 perf_table([% write %], [% state %], data[0], data[1], data[2], pnp_url, [% IF svc == '_HOST_' %]true[% ELSE %]false[% END %]);

--- a/templates/_third_graph.tt
+++ b/templates/_third_graph.tt
@@ -1,8 +1,8 @@
 ﻿[% USE date %]
 <script type="text/javascript">
-  var graph_url = "[% graph_url %]";
+  var graph_url = "[% escape_quotes(graph_url) %]";
 
-if(/render/.test('[% graph_url %]')) {
+if(/render/.test("[% escape_quotes(graph_url) %]")) {
 
 document.write('<div class="commentTitle">Performance Graph<\/div>');
 document.write('<table border="0" class="comment blockHeadBorder">');
@@ -22,7 +22,7 @@ document.write('<tr class="comment" style="cursor:pointer">');
   document.write('<tr>');
     document.write('<td colspan=7 align="center">');
       document.write('<div id="pnp_graph_pane" style="position: relative;">');
-        document.write('<a href="[% graph_url %]">');
+        document.write('<a href="[% escape_quotes(graph_url) %]">');
           document.write('<img id="pnpwaitimg" src="[% url_prefix %]thruk/themes/[% theme %]/images/waiting.gif" style="z-index:100; position: absolute; top:45%; left:45%;" alt="waiting">');
           document.write('<img id="graphiteimg" src="[% url_prefix %]thruk/themes/[% theme %]/images/waiting.gif" style="display:none" alt="graphite graph">');
         document.write('<\/a>');
@@ -52,7 +52,7 @@ document.write('<\/table>');
   document.write('<div id="third_graph_pane" style="position: relative; border-color:#C4C2C2; border-style:ridge; border-width:2px; border-collapse: separate; border-spacing:2px; width:825px; margin-right:275px;">');
   document.write('<div class="commentTitle">Performance Graph<\/div>');
   document.write('<\/br><\/br>');
-  document.write('<iframe name="graph" id="graph" src="[% graph_url %]" width="800" height="500" frameborder="0" style="overflow-x: hidden; overflow-y: scroll;"><\/iframe>');
+  document.write('<iframe name="graph" id="graph" src="[% escape_quotes(graph_url) %]" width="800" height="500" frameborder="0" style="overflow-x: hidden; overflow-y: scroll;"><\/iframe>');
   document.write('<\/div>');
 }
 </script>


### PR DESCRIPTION
Hi!

Here is a small patch to be able to use quotes in action_url statement. Graphite has some function that need quotes for strings parameters. I used the escape quote function as suggested.

Thanks,

Seb
