### PR TITLE
Adding additional use_feature options

### DIFF
--- a/lib/Thruk/Backend/Pool.pm
+++ b/lib/Thruk/Backend/Pool.pm
@@ -81,6 +81,7 @@ sub set_default_config {
         use_feature_statuswrl           => 0,
         use_feature_histogram           => 0,
         use_feature_configtool          => 0,
+        use_feature_recurring_downtime  => 1,
         use_new_search                  => 1,
         use_new_command_box             => 1,
         all_problems_link               => $config->{'url_prefix'}."thruk/cgi-bin/status.cgi?style=combined&amp;hst_s0_hoststatustypes=4&amp;hst_s0_servicestatustypes=31&amp;hst_s0_hostprops=10&amp;hst_s0_serviceprops=0&amp;svc_s0_hoststatustypes=3&amp;svc_s0_servicestatustypes=28&amp;svc_s0_hostprops=10&amp;svc_s0_serviceprops=10&amp;svc_s0_hostprop=2&amp;svc_s0_hostprop=8&amp;title=All+Unhandled+Problems",

--- a/lib/Thruk/Controller/Root.pm
+++ b/lib/Thruk/Controller/Root.pm
@@ -51,7 +51,7 @@ sub begin : Private {
                   show_backends_in_table host_action_icon service_action_icon cookie_path
                   use_feature_trends show_error_reports skip_js_errors perf_bar_mode
                   bug_email_rcpt home_link first_day_of_week sitepanel perf_bar_pnp_popup
-                  status_color_background show_logout_button
+                  status_color_background show_logout_button use_feature_recurring_downtime
                 /) {
         $c->stash->{$key} = $c->config->{$key};
     }

--- a/menu.conf
+++ b/menu.conf
@@ -50,7 +50,7 @@ add_section('name' => 'Reports');
 add_section('name' => 'System');
   add_link('name' => 'Comments',          'href' => '/thruk/cgi-bin/extinfo.cgi?type=3');
   add_link('name' => 'Downtimes',         'href' => '/thruk/cgi-bin/extinfo.cgi?type=6');
-    add_sub_link('name' => 'Recurring Downtimes', 'href' => '/thruk/cgi-bin/extinfo.cgi?type=6&amp;recurring');
+    add_sub_link('name' => 'Recurring Downtimes', 'href' => '/thruk/cgi-bin/extinfo.cgi?type=6&amp;recurring') if $c->stash->{'use_feature_recurring_downtime'};
   add_link('name' => 'Process Info',      'href' => '/thruk/cgi-bin/extinfo.cgi?type=0');
   add_link('name' => 'Performance Info',  'href' => '/thruk/cgi-bin/extinfo.cgi?type=4');
   add_link('name' => 'Scheduling Queue',  'href' => '/thruk/cgi-bin/extinfo.cgi?type=7');

--- a/templates/extinfo_type_1.tt
+++ b/templates/extinfo_type_1.tt
@@ -428,7 +428,7 @@
                 <td valign="middle"><img src='[% url_prefix %]thruk/themes/[% theme %]/images/downtime.gif' border="0" alt="#########" width="20" height="20"></td>
                 <td class='comment'>
                   <a href='cmd.cgi?cmd_typ=55&amp;host=[% host.name | uri %]&amp;backend=[% host.peer_key %]' class='comment'>Add a new downtime</a> |
-                  <a href='extinfo.cgi?type=6&amp;recurring=add&amp;target=host&amp;host=[% host.name | uri %]&amp;backend=[% host.peer_key %]' class='comment'>Add recurring downtime</a>
+                  [% IF use_feature_recurring_downtime %]<a href='extinfo.cgi?type=6&amp;recurring=add&amp;target=host&amp;host=[% host.name | uri %]&amp;backend=[% host.peer_key %]' class='comment'>Add recurring downtime</a>[% END %]
                 </td>
                 [% END %]
                 [% IF downtimes %]
@@ -442,7 +442,7 @@
             [% IF downtimes.size > 0 %]
               [% PROCESS _downtimes_table.tt downtimes = downtimes type='host' names=0 %]
             [% END %]
-            [% IF recurring_downtimes.size > 0 %]
+            [% IF recurring_downtimes.size > 0 && use_feature_recurring_downtime %]
               <div class='commentTitle'>Recurring Host Downtime</div>
               [% PROCESS _downtimes_recurring_table.tt downtimes = recurring_downtimes type='host' %]
             [% END %]

--- a/templates/extinfo_type_2.tt
+++ b/templates/extinfo_type_2.tt
@@ -430,7 +430,7 @@
                 <td valign="middle"><img src='[% url_prefix %]thruk/themes/[% theme %]/images/downtime.gif' border="0" alt="#########" width="20" height="20"></td>
                 <td class='comment'>
                   <a href='cmd.cgi?cmd_typ=56&amp;host=[% service.host_name | uri %]&amp;service=[% service.description | uri %]&amp;backend=[% service.peer_key %]' class='comment'>Add a new downtime</a> |
-                  <a href='extinfo.cgi?type=6&amp;recurring=add&amp;target=service&amp;host=[% service.host_name | uri %]&amp;service=[% service.description | uri %]&amp;backend=[% service.peer_key %]' class='comment'>Add recurring downtime</a>
+                  [% IF use_feature_recurring_downtime %]<a href='extinfo.cgi?type=6&amp;recurring=add&amp;target=service&amp;host=[% service.host_name | uri %]&amp;service=[% service.description | uri %]&amp;backend=[% service.peer_key %]' class='comment'>Add recurring downtime</a>[% END %]
                 </td>
                 [% END %]
                 [% IF downtimes %]
@@ -444,7 +444,7 @@
             [% IF downtimes.size > 0 %]
               [% PROCESS _downtimes_table.tt downtimes = downtimes type='service' names=0 %]
             [% END %]
-            [% IF recurring_downtimes.size > 0 %]
+            [% IF recurring_downtimes.size > 0 && use_feature_recurring_downtime %]
               <div class='commentTitle'>Recurring Service Downtime</div>
               [% PROCESS _downtimes_recurring_table.tt downtimes = recurring_downtimes type='service' %]
             [% END %]

--- a/thruk.conf
+++ b/thruk.conf
@@ -78,6 +78,10 @@ use_feature_histogram = 0
 use_feature_trends = 1 
 
 ######################################
+# use recurring downtime, shows recurring downtime links
+use_feature_recurring_downtime = 1 
+
+######################################
 # normally passive checks would be marked as disabled.
 # with this option, disabled checks will only be displayed as disabled
 # if their last result was active


### PR DESCRIPTION
The use_feature_recurring_downtime option allows for user to hide the recurring downtime links if they so choose.

The use_feature_histogram and use_feature_trends were not in thruk.conf and don't get set by any plugins.
