### PR TITLE
Fix RPM builds

### DIFF
--- a/lib/Catalyst/Plugin/Thruk/ConfigLoader.pm
+++ b/lib/Catalyst/Plugin/Thruk/ConfigLoader.pm
@@ -48,6 +48,8 @@ sub _do_finalize_config {
     ###################################################
     # switch user when running as root
     my $var_path = $config->{'var_path'} or die("no var path!");
+    # return here if we are doing an RPM build
+    return if (defined $ENV{'RPM_PACKAGE_NAME'}); 
     if($> != 0 and !-d ($var_path.'/.')) { CORE::mkdir($var_path); }
     die("'".$var_path."/.' does not exist, make sure it exists and has proper user/groups/permissions") unless -d ($var_path.'/.');
     my ($uid, $groups) = get_user($var_path);


### PR DESCRIPTION
When doing an RPM build you typically run Makefile.PL in the %build section. This is before whatever you have configured for your var_path has been created if on a fresh machine. When loading the thruk configuration it's final steps are to check if that directory exists, gather user information from it and switch users. This is not necessary during our build process.

You can replicate this issue by setting up a machine without the var_path directory created. Then run script/thruk_create_combined_static_content.pl (now part of Makefile.PL) which should fail to complete until var_path is created.
