### PR TITLE
Changed services_log mysql query because as is it is too slow for large installations

### DIFF
--- a/lib/Thruk/Backend/Provider/Mysql.pm
+++ b/lib/Thruk/Backend/Provider/Mysql.pm
@@ -1249,26 +1249,42 @@ sub _get_log_host_auth {
 sub _get_log_service_auth {
     my($self,$dbh, $prefix, $contact) = @_;
 
-    my $sql = "SELECT h.host_name, s.service_description
+    # Select all Services where the host is allowed by contact
+    my $sql1 = "SELECT h.host_name, s.service_description
                FROM
                  `".$prefix."_service` s,
                  `".$prefix."_host` h,
                  `".$prefix."_contact_host_rel` chr,
                  `".$prefix."_contact` c1,
-                 `".$prefix."_contact_service_rel` csr,
-                 `".$prefix."_contact` c2
+                 `".$prefix."_contact_service_rel` csr
                WHERE
                  s.host_id = h.host_id
                  AND h.host_id = chr.host_id
                  AND c1.contact_id = chr.contact_id
-                 AND c2.contact_id = csr.contact_id
                  AND s.service_id = csr.service_id
-                 AND (c1.name = ".$dbh->quote($contact)."
-                   OR c2.name = ".$dbh->quote($contact).")"
+                 AND c1.name = ".$dbh->quote($contact)
                ;
-    my $services        = $dbh->selectall_arrayref($sql);
+    # Select all Services which are directly allowed by contact
+    my $sql2 = "SELECT h.host_name, s.service_description
+               FROM
+                 `".$prefix."_service` s,
+                 `".$prefix."_host` h,
+                 `".$prefix."_contact_host_rel` chr,
+                 `".$prefix."_contact` c1,
+                 `".$prefix."_contact_service_rel` csr
+               WHERE
+                 s.host_id = h.host_id
+                 AND h.host_id = chr.host_id
+                 AND c1.contact_id = csr.contact_id
+                 AND s.service_id = csr.service_id
+                 AND c1.name = ".$dbh->quote($contact)
+		;
+    my $services1        = $dbh->selectall_arrayref($sql1);
+    my $services2        = $dbh->selectall_arrayref($sql2);
+    # Make them unique
     my $services_lookup = {};
-    for my $s (@{$services}) { $services_lookup->{$s->[0]}->{$s->[1]} = 1; }
+    for my $s (@{$services1}) { $services_lookup->{$s->[0]}->{$s->[1]} = 1; }
+    for my $s (@{$services2}) { $services_lookup->{$s->[0]}->{$s->[1]} = 1; }
     return $services_lookup;
 }
 


### PR DESCRIPTION
The query in the MySQL backend for getting services to see log entries for a special user has too many joins. I split the query in two so that it is much faster now (still not as fast as
one would like but workable ;)
