### PR TITLE
Fix pnp4nagios wait img

### DIFF
--- a/root/thruk/javascript/thruk-1.74.js
+++ b/root/thruk/javascript/thruk-1.74.js
@@ -4071,12 +4071,19 @@ function set_png_img(start, end, id) {
     //debug(newUrl);
 
     jQuery('#pnpwaitimg').css('display', 'block');
-    jQuery('#pnpimg').attr('src', newUrl);
-
-    jQuery('#pnpimg').load(function() {
-      jQuery('#pnpimg').css('display' , 'block');
+    jQuery('<img id="pnpimg" src="' + newUrl + '" alt="pnp graph">')
+    .error(function () {
+      jQuery('#pnperror').css('display', 'block');
+      jQuery('#pnpwaitimgspace').css('display', 'none');
       jQuery('#pnpwaitimg').css('display', 'none');
-    });
+    })
+    .load(function() {
+        //jQuery('#pnpimg').css('display', 'block');
+        jQuery('#pnpimg_div').html(this);
+        jQuery('#pnpwaitimgspace').css('display', 'none');
+        jQuery('#pnpwaitimg').css('display', 'none');
+    })
+    .attr('src', newUrl);
 
     // set style of buttons
     if(id) {

--- a/templates/_pnp_graph.tt
+++ b/templates/_pnp_graph.tt
@@ -22,9 +22,10 @@
       <div id="pnp_graph_pane" style="position: relative;">
         <a href="[% pnp_url %]/graph?host=[% hst | uri %]&amp;srv=[% svc | uri %]&theme=smoothness">
           <img id="pnpwaitimg" src="[% url_prefix %]thruk/themes/[% theme %]/images/waiting.gif" style="z-index:100; position: absolute; top:45%; left:45%;" alt="waiting">
-          <img id="pnpimg" src="[% url_prefix %]thruk/themes/[% theme %]/images/waiting.gif" style="display:none" alt="pnp graph">
+          <div id="pnpimg_div"></div>
         </a>
-      </div>
+      <div id="pnperror" style="display:none">Could not retrieve graph data</div>
+      <div id="pnpwaitimgspace"><br><br></div>
     </td>
   </tr>
 </table>

--- a/templates/extinfo_type_1.tt
+++ b/templates/extinfo_type_1.tt
@@ -391,6 +391,11 @@
         [% END %]
 
         <tr>
+          <td colspan="2">
+            <br>
+          </td>
+        </tr>
+        <tr>
           <td colspan="2" align="center" valign="top" class='commentPanel'>
           [% IF c.check_cmd_permissions('host', host.name) %]
             <a name="comments" id="comments"></a>


### PR DESCRIPTION
When loading a host/service and pnp4nagios is enabled but the graph doesn't exist the wait img will run forever. If in FF or IE if you refresh no wait img appears at all. This commit should hopefully fix the issue where a broken pnp4nagios link will result in a proper message and prevent the wait img from spinning forever. It also fixes some spacing issues that were present where the wait img would cover parts of the comments section. This has only been tested in FF, IE and chrome.
