### PR TITLE
Fix squished pnp error on host information page

### DIFF
--- a/templates/extinfo_type_1.tt
+++ b/templates/extinfo_type_1.tt
@@ -391,6 +391,11 @@
         [% END %]
 
         <tr>
+          <td colspan="2">
+            <br>
+          </td>
+        </tr>
+        <tr>
           <td colspan="2" align="center" valign="top" class='commentPanel'>
           [% IF c.check_cmd_permissions('host', host.name) %]
             <a name="comments" id="comments"></a>


### PR DESCRIPTION
When a host doesn't have any perfdata and the error is displayed things are some what squished. This doesn't happen on the service information page because of an extra row with a break. This adds the same spacing to the host information page.
