### PR TITLE
Fix invalid ordering when local_perf_bar_mode is "worst"

### DIFF
--- a/root/thruk/javascript/thruk-1.76.js
+++ b/root/thruk/javascript/thruk-1.76.js
@@ -1167,6 +1167,11 @@ var sort_by = function(field, reverse, primer) {
    }
 }
 
+/* numeric comparison function */
+function compareNumeric(a, b) {
+   return a - b;
+}
+
 /* make right pane visible */
 function cron_change_date(id) {
     // get selected value
@@ -1569,8 +1574,8 @@ function perf_parse_data(check_command, state, plugin_output, perfdata) {
 
     if(local_perf_bar_mode == 'worst') {
         if(keys(worst_graphs).length == 0) { return([]); }
-        var sortedkeys   = keys(worst_graphs).sort().reverse();
-        var sortedgraphs = keys(worst_graphs[sortedkeys[0]]).sort().reverse();
+        var sortedkeys   = keys(worst_graphs).sort(compareNumeric).reverse();
+        var sortedgraphs = keys(worst_graphs[sortedkeys[0]]).sort(compareNumeric).reverse();
         return([worst_graphs[sortedkeys[0]][sortedgraphs[0]]]);
     }
     if(local_perf_bar_mode == 'match') {


### PR DESCRIPTION
The default Javascript sort implementation is lexicographic rather than
numeric, leading to 100 being sorted before 20.
