### PR TITLE
Fix calendar UI issue

### DIFF
--- a/themes/themes-available/Exfoliation/stylesheets/common.css
+++ b/themes/themes-available/Exfoliation/stylesheets/common.css
@@ -50,7 +50,6 @@ body {
 
 table {
   border: none;
-  margin: 0;
 }
 
 th, td {

--- a/themes/themes-available/Neat/stylesheets/common.css
+++ b/themes/themes-available/Neat/stylesheets/common.css
@@ -135,7 +135,6 @@ A IMG {
 
 TABLE {
  border: none;
- margin: 0;
 }
 
 TH, TD {


### PR DESCRIPTION
When using the Exfoliation or Neat themes there is an issue with the month not being aligned properly on the js calendar that would popup in some cases. Scheduling downtime is a good example of when the calendar may get used.

I am able to replicate this issue on demo.thruk.org. I have only tested using chrome and firefox. Changing this doesn't seem to vastly affect the look of anything else.

Also, this issue seems to happen on the Vautor theme as well but the CSS is pretty different there and I wasn't able  quickly to track down what needed to be changed in that theme.
