### PR TITLE
Make set_custom_vars() more extensible

### DIFF
--- a/lib/Thruk/Controller/extinfo.pm
+++ b/lib/Thruk/Controller/extinfo.pm
@@ -634,14 +634,7 @@ sub _process_host_page {
     $c->stash->{'recurring_downtimes'} = $self->_get_downtimes_list($c, 1, $hostname);
 
     # set allowed custom vars into stash
-    Thruk::Utils::set_custom_vars($c, $host);
-
-    # expand macros in custom vars
-    if(defined $host) {
-        for my $var (@{$c->stash->{'custom_vars'}}) {
-            ($var->[1], my $rc) = $c->{'db'}->_replace_macros({string => $var->[1], host => $host});
-        }
-    }
+    Thruk::Utils::set_custom_vars($c, $host, undef, undef, undef, $host);
 
     return 1;
 }
@@ -765,14 +758,7 @@ sub _process_service_page {
     $c->stash->{'recurring_downtimes'} = $self->_get_downtimes_list($c, 1, $hostname, $servicename);
 
     # set allowed custom vars into stash
-    Thruk::Utils::set_custom_vars($c, $service);
-
-    # expand macros in custom vars
-    if(defined $host and defined $service) {
-        for my $var (@{$c->stash->{'custom_vars'}}) {
-            ($var->[1], my $rc) = $c->{'db'}->_replace_macros({string => $var->[1], host => $host, service => $service});
-        }
-    }
+    Thruk::Utils::set_custom_vars($c, $service, undef, undef, undef, $host, $service);
 
     return 1;
 }

--- a/lib/Thruk/Controller/status.pm
+++ b/lib/Thruk/Controller/status.pm
@@ -399,12 +399,7 @@ sub _process_details_page {
         }
 
         # set allowed custom vars into stash
-        Thruk::Utils::set_custom_vars($c, $host);
-
-        # expand macros in custom vars
-        for my $var (@{$c->stash->{'custom_vars'}}) {
-            ($var->[1], my $rc) = $c->{'db'}->_replace_macros({string => $var->[1], host => $host});
-        }
+        Thruk::Utils::set_custom_vars($c, $host, undef, undef, undef, $host);
     }
 
     return 1;


### PR DESCRIPTION
The set_custom_vars function was only able to process 'show_custom_vars' but there will likely be a need in the future to do the same processing on other custom variables that are either specified by the user and the configuration file or by the inner workings of Thruk itself. This will hopefully reduce code and duplication of effort. Also, moved the expansion of macros into the set_custom_vars function as well.

Note that I tired to keep calls to set_custom_vars backwards compatible. If that isn't something you care about in this case than it might be nicer to pass a hash to this function when calling it similar to how you do it with _get_macros() and _replace_macros(). Just my opinion.
