### PR TITLE
Cleanup calls to set_custom_vars()

### DIFF
--- a/lib/Thruk/Controller/extinfo.pm
+++ b/lib/Thruk/Controller/extinfo.pm
@@ -634,7 +634,7 @@ sub _process_host_page {
     $c->stash->{'recurring_downtimes'} = $self->_get_downtimes_list($c, 1, $hostname);
 
     # set allowed custom vars into stash
-    Thruk::Utils::set_custom_vars($c, $host, undef, undef, undef, $host);
+    Thruk::Utils::set_custom_vars($c, {'host' => $host});
 
     return 1;
 }
@@ -758,7 +758,7 @@ sub _process_service_page {
     $c->stash->{'recurring_downtimes'} = $self->_get_downtimes_list($c, 1, $hostname, $servicename);
 
     # set allowed custom vars into stash
-    Thruk::Utils::set_custom_vars($c, $service, undef, undef, undef, $host, $service);
+    Thruk::Utils::set_custom_vars($c, {'host' => $host, 'service' => $service});
 
     return 1;
 }

--- a/lib/Thruk/Controller/status.pm
+++ b/lib/Thruk/Controller/status.pm
@@ -399,7 +399,7 @@ sub _process_details_page {
         }
 
         # set allowed custom vars into stash
-        Thruk::Utils::set_custom_vars($c, $host, undef, undef, undef, $host);
+        Thruk::Utils::set_custom_vars($c, {'host' => $host});
     }
 
     return 1;

--- a/lib/Thruk/Utils.pm
+++ b/lib/Thruk/Utils.pm
@@ -927,10 +927,23 @@ set stash value for all allowed custom variables
 
 =cut
 sub set_custom_vars {
-    my($c, $data, $prefix, $search, $dest, $host, $service) = @_;
-    $prefix = ''                 unless defined $prefix;
-    $search = 'show_custom_vars' unless defined $search;
-    $dest   = 'custom_vars'      unless defined $dest;
+    my $c      = shift;
+    my $args   = shift;
+
+    my $prefix  = $args->{'prefix'} || '';
+    my $search  = $args->{'search'} || 'show_custom_vars';
+    my $dest    = $args->{'dest'}   || 'custom_vars';
+    my $host    = $args->{'host'};
+    my $service = $args->{'service'};
+    my $data;
+
+    if (defined $host and defined $service) {
+        $data = $service;
+    } elsif (defined $host) {
+        $data = $host;
+    } else {
+        return;
+    }
 
     $c->stash->{$dest} = [];
 


### PR DESCRIPTION
Moved to passing a hash as one of the parameters to make things a bit easier to work with.
