### PR TITLE
Make the code that expands host macros more flexible

### DIFF
--- a/lib/Thruk/Backend/Manager.pm
+++ b/lib/Thruk/Backend/Manager.pm
@@ -921,21 +921,23 @@ sub _set_host_macros {
     my $c = $Thruk::Backend::Manager::c;
 
     # normal host macros
-    $macros->{'$HOSTADDRESS$'}       = $host->{'address'};
-    $macros->{'$HOSTNAME$'}          = $host->{'name'};
-    $macros->{'$HOSTALIAS$'}         = $host->{'alias'};
-    $macros->{'$HOSTSTATEID$'}       = $host->{'state'};
-    $macros->{'$HOSTSTATE$'}         = $c->config->{'nagios'}->{'host_state_by_number'}->{$host->{'state'}};
-    $macros->{'$HOSTLATENCY$'}       = $host->{'latency'};
-    $macros->{'$HOSTOUTPUT$'}        = $host->{'plugin_output'};
-    $macros->{'$HOSTPERFDATA$'}      = $host->{'perf_data'};
-    $macros->{'$HOSTATTEMPT$'}       = $host->{'current_attempt'};
-    $macros->{'$HOSTCHECKCOMMAND$'}  = $host->{'check_command'};
+    $macros->{'$HOSTADDRESS$'}       = (defined $host->{'host_address'})         ? $host->{'host_address'}         : $host->{'address'};
+    $macros->{'$HOSTNAME$'}          = (defined $host->{'host_name'})            ? $host->{'host_name'}            : $host->{'name'};
+    $macros->{'$HOSTALIAS$'}         = (defined $host->{'host_alias'})           ? $host->{'host_alias'}           : $host->{'alias'};
+    $macros->{'$HOSTSTATEID$'}       = (defined $host->{'host_state'})           ? $host->{'host_state'}           : $host->{'state'};
+    $macros->{'$HOSTLATENCY$'}       = (defined $host->{'host_latency'})         ? $host->{'host_latency'}         : $host->{'latency'};
+    $macros->{'$HOSTOUTPUT$'}        = (defined $host->{'host_plugin_output'})   ? $host->{'host_plugin_output'}   : $host->{'plugin_output'};
+    $macros->{'$HOSTPERFDATA$'}      = (defined $host->{'host_perf_data'})       ? $host->{'host_perf_data'}       : $host->{'perf_data'};
+    $macros->{'$HOSTATTEMPT$'}       = (defined $host->{'host_current_attempt'}) ? $host->{'host_current_attempt'} : $host->{'current_attempt'};
+    $macros->{'$HOSTCHECKCOMMAND$'}  = (defined $host->{'host_check_command'})   ? $host->{'host_check_command'}   : $host->{'check_command'};
+    $macros->{'$HOSTSTATE$'}         = $c->config->{'nagios'}->{'host_state_by_number'}->{$macros->{'$HOSTSTATEID$'}};
+    
+    my $prefix = (defined $host->{'host_custom_variable_names'}) ? 'host_' : '';
 
     # host user macros
     my $x = 0;
-    for my $key (@{$host->{'custom_variable_names'}}) {
-        $macros->{'$_HOST'.$key.'$'}  = $host->{'custom_variable_values'}->[$x];
+    for my $key (@{$host->{$prefix.'custom_variable_names'}}) {
+        $macros->{'$_HOST'.$key.'$'}  = $host->{$prefix.'custom_variable_values'}->[$x];
         $x++;
     }
 

--- a/lib/Thruk/Backend/Provider/Livestatus.pm
+++ b/lib/Thruk/Backend/Provider/Livestatus.pm
@@ -382,6 +382,7 @@ sub get_services {
             execution_time first_notification_delay flap_detection_enabled groups
             has_been_checked high_flap_threshold host_acknowledged host_action_url_expanded
             host_active_checks_enabled host_address host_alias host_checks_enabled host_check_type
+            host_latency host_plugin_output host_perf_data host_current_attempt host_check_command
             host_comments host_groups host_has_been_checked host_icon_image_expanded host_icon_image_alt
             host_is_executing host_is_flapping host_name host_notes_url_expanded
             host_notifications_enabled host_scheduled_downtime_depth host_state host_accept_passive_checks

--- a/lib/Thruk/Controller/extinfo.pm
+++ b/lib/Thruk/Controller/extinfo.pm
@@ -720,24 +720,10 @@ sub _process_service_page {
     }
 
     # generate command line
-    my $host;	
     if($c->{'stash'}->{'show_full_commandline'} == 2 ||
        $c->{'stash'}->{'show_full_commandline'} == 1 && $c->check_user_roles( "authorized_for_configuration_information" ) ) {
-        my $hosts               = $c->{'db'}->get_hosts( filter => [ Thruk::Utils::Auth::get_auth_filter( $c, 'hosts' ), { 'name' => $hostname } ] );
-        # we only got one host
-        $host = $hosts->[0];
-        # we have more and backend param is used
-        if( scalar @{$hosts} == 1 and defined $backend ) {
-            for my $h ( @{$hosts} ) {
-                if( $h->{'peer_key'} eq $backend ) {
-                    $host = $h;
-                    last;
-                }
-            }
-        }
-        $c->stash->{'command'}  = '';
-        if(defined $host and defined $service) {
-            my $command            = $c->{'db'}->expand_command('host' => $host, 'service' => $service, 'source' => $c->config->{'show_full_commandline_source'} );
+        if(defined $service) {
+            my $command            = $c->{'db'}->expand_command('host' => $service, 'service' => $service, 'source' => $c->config->{'show_full_commandline_source'} );
             $c->stash->{'command'} = $command;
         }
     }
@@ -758,7 +744,7 @@ sub _process_service_page {
     $c->stash->{'recurring_downtimes'} = $self->_get_downtimes_list($c, 1, $hostname, $servicename);
 
     # set allowed custom vars into stash
-    Thruk::Utils::set_custom_vars($c, {'host' => $host, 'service' => $service});
+    Thruk::Utils::set_custom_vars($c, {'host' => $service, 'service' => $service});
 
     return 1;
 }

--- a/lib/Thruk/Controller/status.pm
+++ b/lib/Thruk/Controller/status.pm
@@ -380,26 +380,8 @@ sub _process_details_page {
        and defined $c->stash->{'host_stats'}
        and defined $c->stash->{'host_stats'}->{'up'}
        and $c->stash->{'host_stats'}->{'up'} + $c->stash->{'host_stats'}->{'down'} + $c->stash->{'host_stats'}->{'unreachable'} + $c->stash->{'host_stats'}->{'pending'} == 1) {
-        # gather some necessary variables
-        my $backend  = $c->{'request'}->{'parameters'}->{'backend'} || '';
-        my $hostname = $c->{'request'}->{'parameters'}->{'host'};
-        my $host; 
-
-        my $hosts = $c->{'db'}->get_hosts( filter => [ Thruk::Utils::Auth::get_auth_filter( $c, 'hosts' ), { 'name' => $hostname } ] );
-        # we only got one host
-        $host = $hosts->[0];
-        # we have more and backend param is used
-        if( scalar @{$hosts} == 1 and defined $backend ) {
-            for my $h ( @{$hosts} ) {
-                if( $h->{'peer_key'} eq $backend ) {
-                    $host = $h;
-                    last;
-                }
-            }
-        }
-
         # set allowed custom vars into stash
-        Thruk::Utils::set_custom_vars($c, {'host' => $host});
+        Thruk::Utils::set_custom_vars($c, {'prefix' => 'host_', 'host' => $c->{'stash'}->{'data'}->[0]});
     }
 
     return 1;


### PR DESCRIPTION
This helps reduce code in other places so you don't have to find the host object each time you want to expand macros.
