### PR TITLE
Reports with attachments should keep the dot in the name

### DIFF
--- a/plugins/plugins-available/reports2/lib/Thruk/Utils/Reports.pm
+++ b/plugins/plugins-available/reports2/lib/Thruk/Utils/Reports.pm
@@ -85,7 +85,7 @@ sub report_show {
         elsif($report->{'var'}->{'attachment'}) {
             my $name = $report->{'var'}->{'attachment'};
             $name    =~ s/\s+/_/gmx;
-            $name    =~ s/[^a-zA-Z0-9-_]+//gmx;
+            $name    =~ s/[^a-zA-Z0-9-_\.]+//gmx;
             $c->res->header( 'Content-Disposition', 'attachment; filename="'.$name.'"' );
             $c->res->content_type($report->{'var'}->{'ctype'}) if $report->{'var'}->{'ctype'};
             open(my $fh, '<', $report_file);


### PR DESCRIPTION
See #259: when creating a report from url that creates an attachment (e.g. availability.xls), the "." was removed from the name when the client wanted to download the attachment. This change fixes this.
