### PR TITLE
Extend 0004-thruk_data_scripts.patch to include fcgid_env.sh

### DIFF
--- a/support/0004-thruk_data_scripts.patch
+++ b/support/0004-thruk_data_scripts.patch
@@ -1,10 +1,10 @@
---- a/fcgid_env.sh	2014-02-17 16:13:20.000000000 -0500
-+++ b/fcgid_env.sh	2014-02-18 09:36:25.234643864 -0500
+--- a/fcgid_env.sh	2014-02-17 13:51:42.604007060 -0500
++++ b/fcgid_env.sh	2014-02-18 09:50:22.631111321 -0500
 @@ -1,7 +1,7 @@
  #!/bin/bash
  
  # set omd environment
--export CATALYST_CONFIG="/usr/local/thruk/etc"
+-export CATALYST_CONFIG="/etc/thruk"
 +export CATALYST_CONFIG="@SYSCONFDIR@"
  
  # load extra environment variables
@@ -13,10 +13,10 @@
  [ -e ~/.thruk ] && . ~/.thruk
  
  # execute fastcgi server
--exec /usr/local/thruk/share/script/thruk_fastcgi.pl
+-exec /usr/share/thruk/script/thruk_fastcgi.pl
 +exec @DATADIR@/script/thruk_fastcgi.pl
 --- a/script/thruk_fastcgi.pl	2014-02-17 13:51:42.602007012 -0500
-+++ b/script/thruk_fastcgi.pl	2014-02-18 09:33:54.458143509 -0500
++++ b/script/thruk_fastcgi.pl	2014-02-18 09:49:13.206496762 -0500
 @@ -3,6 +3,9 @@
  use strict;
  use warnings;
@@ -28,7 +28,7 @@
  # create connection pool
  # has to be done really early to save memory
 --- a/thruk_auth	2014-02-17 13:51:42.602007012 -0500
-+++ b/thruk_auth	2014-02-18 09:33:54.458143509 -0500
++++ b/thruk_auth	2014-02-18 09:49:13.206496762 -0500
 @@ -12,8 +12,9 @@
    export PERL5LIB=$OMD_ROOT/share/thruk/lib:$PERL5LIB
    if [ -z $CATALYST_CONFIG ]; then export CATALYST_CONFIG="$OMD_ROOT/etc/thruk"; fi


### PR DESCRIPTION
This extends 0004-thruk_data_scripts.patch to fix some of the
hardcoded paths in fcgid_env.sh with those specified by the
configure command that was run by the user.
