### PR TITLE
Fix format_number() to not go passed decimal point

### DIFF
--- a/lib/Thruk/Utils.pm
+++ b/lib/Thruk/Utils.pm
@@ -89,7 +89,11 @@ return number with thousands seperator
 =cut
 sub format_number {
     my($number) = @_;
-    $number =~ s/(\d{1,3}?)(?=(\d{3})+$)/$1,/gmx;
+    for ($number) {
+        /\./
+        ? s/(?<=\d)(?=(\d{3})+(?:\.))/,/g
+        : s/(?<=\d)(?=(\d{3})+(?!\d))/,/g;
+    }
     return $number;
 }
 


### PR DESCRIPTION
If perfdata was like 0.010445s than format_number() would
change that to be 0.010,445s when displaying the human readable
format. Stole this thousands seperator from perl monks which was
contribued by Roger (http://www.perlmonks.org/?node_id=320265)
that seems to work well and fixes the issue of formatting past the
decimal point.
