### PR TITLE
Fixes to Plugin Output search

### DIFF
--- a/lib/Thruk/Utils/Status.pm
+++ b/lib/Thruk/Utils/Status.pm
@@ -795,8 +795,10 @@ sub single_search {
             push @servicetotalsfilter, { host_parents => { $listop => $value } };
         }
         elsif ( $filter->{'type'} eq 'plugin output' ) {
-            push @hostfilter,    { -or => [ plugin_output => { $op => $value }, long_plugin_output => { $op => $value } ] };
-            push @servicefilter, { -or => [ plugin_output => { $op => $value }, long_plugin_output => { $op => $value } ] };
+            my $cop = '-or';
+            if($op eq '!=' or $op eq '!~~') { $cop = '-and' }
+            push @hostfilter,    { $cop => [ plugin_output => { $op => $value }, long_plugin_output => { $op => $value } ] };
+            push @servicefilter, { $cop => [ plugin_output => { $op => $value }, long_plugin_output => { $op => $value } ] };
         }
         # Root Problems are only available in Shinken
         elsif ( $filter->{'type'} eq 'rootproblem' && $c->stash->{'enable_shinken_features'}) {

--- a/root/thruk/javascript/thruk-1.82.js
+++ b/root/thruk/javascript/thruk-1.82.js
@@ -3182,6 +3182,7 @@ function add_new_filter(search_prefix, table) {
                              'Notification Period',
                              'Number of Services',
                              'Parent',
+                             'Plugin Output',
                              'Service',
                              'Servicegroup',
                              '% State Change'


### PR DESCRIPTION
Fixed issue where inclusion would work fine but exluding would not because
of the wrong operator being used.

Also, fixed issue where when user would add another filter the "Plugin Output"
option would not be present. The option was only available in the first filter.
