### PR TITLE
Better sorting of comments and downtimes

### DIFF
--- a/lib/Thruk/Controller/extinfo.pm
+++ b/lib/Thruk/Controller/extinfo.pm
@@ -106,7 +106,7 @@ sub _get_comment_sort_option {
         '9' => [ [ 'expires' ],                            'expires' ],
     };
 
-    return (defined $sortoptions->{$option}) ? $sortoptions->{$option} : undef;
+    return $sortoptions->{$option};
 }
 
 ##########################################################
@@ -128,7 +128,7 @@ sub _get_downtime_sort_option {
         '11' =>[ [ 'triggered_by' ],                       'trigger id' ],
     };
 
-    return (defined $sortoptions->{$option}) ? $sortoptions->{$option} : undef;
+    return $sortoptions->{$option};
 }
 
 ##########################################################
@@ -143,8 +143,9 @@ sub _process_comments_page {
     my $svc_order      = "ASC";
     $svc_order = "DESC" if $svc_sorttype == 2;
     $svc_sortoption = 1 if !defined $self->_get_comment_sort_option($svc_sortoption);
-    $c->stash->{'svc_orderby'}  = $self->_get_comment_sort_option($svc_sortoption)->[1];
-    $c->stash->{'svc_orderdir'} = $svc_order;
+    $c->stash->{'svc_orderby'}    = $self->_get_comment_sort_option($svc_sortoption)->[1];
+    $c->stash->{'svc_orderdir'}   = $svc_order;
+    $c->stash->{'sortoption_svc'} = $c->{'request'}->{'parameters'}->{'sortoption_svc'} || '';
 
     # hosts
     my $hst_sorttype   = $c->{'request'}->{'parameters'}->{'sorttype_hst'}   || 1;
@@ -152,8 +153,9 @@ sub _process_comments_page {
     my $hst_order      = "ASC";
     $hst_order = "DESC" if $hst_sorttype == 2;
     $hst_sortoption = 1 if !defined $self->_get_comment_sort_option($hst_sortoption);
-    $c->stash->{'hst_orderby'}  = $self->_get_comment_sort_option($hst_sortoption)->[1];
-    $c->stash->{'hst_orderdir'} = $hst_order;
+    $c->stash->{'hst_orderby'}    = $self->_get_comment_sort_option($hst_sortoption)->[1];
+    $c->stash->{'hst_orderdir'}   = $hst_order;
+    $c->stash->{'sortoption_hst'} = $c->{'request'}->{'parameters'}->{'sortoption_hst'} || '';
 
     $c->stash->{'hostcomments'}    = $c->{'db'}->get_comments( filter => [ Thruk::Utils::Auth::get_auth_filter( $c, 'comments' ), { 'service_description' => undef } ],
                                                                sort   => { $hst_order => $self->_get_comment_sort_option($hst_sortoption)->[0] },
@@ -190,8 +192,9 @@ sub _process_downtimes_page {
     my $svc_order      = "ASC";
     $svc_order = "DESC" if $svc_sorttype == 2;
     $svc_sortoption = 1 if !defined $self->_get_downtime_sort_option($svc_sortoption);
-    $c->stash->{'svc_orderby'}  = $self->_get_downtime_sort_option($svc_sortoption)->[1];
-    $c->stash->{'svc_orderdir'} = $svc_order;
+    $c->stash->{'svc_orderby'}    = $self->_get_downtime_sort_option($svc_sortoption)->[1];
+    $c->stash->{'svc_orderdir'}   = $svc_order;
+    $c->stash->{'sortoption_svc'} = $c->{'request'}->{'parameters'}->{'sortoption_svc'} || '';
 
     # hosts
     my $hst_sorttype   = $c->{'request'}->{'parameters'}->{'sorttype_hst'}   || 1;
@@ -199,8 +202,9 @@ sub _process_downtimes_page {
     my $hst_order      = "ASC";
     $hst_order = "DESC" if $hst_sorttype == 2;
     $hst_sortoption = 1 if !defined $self->_get_downtime_sort_option($hst_sortoption);
-    $c->stash->{'hst_orderby'}  = $self->_get_downtime_sort_option($hst_sortoption)->[1];
-    $c->stash->{'hst_orderdir'} = $hst_order;
+    $c->stash->{'hst_orderby'}    = $self->_get_downtime_sort_option($hst_sortoption)->[1];
+    $c->stash->{'hst_orderdir'}   = $hst_order;
+    $c->stash->{'sortoption_hst'} = $c->{'request'}->{'parameters'}->{'sortoption_hst'} || '';
 
     $c->stash->{'hostdowntimes'}    = $c->{'db'}->get_downtimes( filter => [ Thruk::Utils::Auth::get_auth_filter( $c, 'downtimes' ), { 'service_description' => undef } ],
                                                                  sort   => { $hst_order => $self->_get_downtime_sort_option($hst_sortoption)->[0] },
@@ -418,8 +422,9 @@ sub _process_host_page {
     my $cmt_order      = "ASC";
     $cmt_order = "DESC" if $cmt_sorttype == 2;
     $cmt_sortoption = 1 if !defined $self->_get_comment_sort_option($cmt_sortoption);
-    $c->stash->{'cmt_orderby'}  = $self->_get_comment_sort_option($cmt_sortoption)->[1];
-    $c->stash->{'cmt_orderdir'} = $cmt_order;
+    $c->stash->{'cmt_orderby'}    = $self->_get_comment_sort_option($cmt_sortoption)->[1];
+    $c->stash->{'cmt_orderdir'}   = $cmt_order;
+    $c->stash->{'sortoption_cmt'} = $c->{'request'}->{'parameters'}->{'sortoption_cmt'} || '';
 
     $c->stash->{'comments'}  = $c->{'db'}->get_comments(
         filter => [ Thruk::Utils::Auth::get_auth_filter( $c, 'comments' ), { 'host_name' => $hostname }, { 'service_description' => undef } ],
@@ -431,8 +436,9 @@ sub _process_host_page {
     my $dtm_order      = "ASC";
     $dtm_order = "DESC" if $dtm_sorttype == 2;
     $dtm_sortoption = 1 if !defined $self->_get_comment_sort_option($dtm_sortoption);
-    $c->stash->{'dtm_orderby'}  = $self->_get_comment_sort_option($dtm_sortoption)->[1];
-    $c->stash->{'dtm_orderdir'} = $dtm_order;
+    $c->stash->{'dtm_orderby'}    = $self->_get_comment_sort_option($dtm_sortoption)->[1];
+    $c->stash->{'dtm_orderdir'}   = $dtm_order;
+    $c->stash->{'sortoption_dtm'} = $c->{'request'}->{'parameters'}->{'sortoption_dtm'} || '';
 
     $c->stash->{'downtimes'} = $c->{'db'}->get_downtimes(
         filter => [ Thruk::Utils::Auth::get_auth_filter( $c, 'downtimes' ), { 'host_name' => $hostname }, { 'service_description' => undef } ],
@@ -546,8 +552,9 @@ sub _process_service_page {
     my $cmt_order      = "ASC";
     $cmt_order = "DESC" if $cmt_sorttype == 2;
     $cmt_sortoption = 1 if !defined $self->_get_comment_sort_option($cmt_sortoption);
-    $c->stash->{'cmt_orderby'}  = $self->_get_comment_sort_option($cmt_sortoption)->[1];
-    $c->stash->{'cmt_orderdir'} = $cmt_order;
+    $c->stash->{'cmt_orderby'}    = $self->_get_comment_sort_option($cmt_sortoption)->[1];
+    $c->stash->{'cmt_orderdir'}   = $cmt_order;
+    $c->stash->{'sortoption_cmt'} = $c->{'request'}->{'parameters'}->{'sortoption_cmt'} || '';
 
     $c->stash->{'comments'} = $c->{'db'}->get_comments(
         filter => [ Thruk::Utils::Auth::get_auth_filter( $c, 'comments' ), { 'host_name' => $hostname }, { 'service_description' => $servicename } ],
@@ -559,8 +566,9 @@ sub _process_service_page {
     my $dtm_order      = "ASC";
     $dtm_order = "DESC" if $dtm_sorttype == 2;
     $dtm_sortoption = 1 if !defined $self->_get_comment_sort_option($dtm_sortoption);
-    $c->stash->{'dtm_orderby'}  = $self->_get_comment_sort_option($dtm_sortoption)->[1];
-    $c->stash->{'dtm_orderdir'} = $dtm_order;
+    $c->stash->{'dtm_orderby'}    = $self->_get_comment_sort_option($dtm_sortoption)->[1];
+    $c->stash->{'dtm_orderdir'}   = $dtm_order;
+    $c->stash->{'sortoption_dtm'} = $c->{'request'}->{'parameters'}->{'sortoption_dtm'} || '';
 
     $c->stash->{'downtimes'} = $c->{'db'}->get_downtimes(
         filter => [ Thruk::Utils::Auth::get_auth_filter( $c, 'downtimes' ), { 'host_name' => $hostname }, { 'service_description' => $servicename } ],

--- a/templates/extinfo_type_1.tt
+++ b/templates/extinfo_type_1.tt
@@ -435,7 +435,9 @@
               </tr>
             </table>
             [% IF comments.size > 0 %]
+              [% IF sortoption_cmt %]
               <div class="statusSort" align="CENTER">Comments sorted by <b>[% cmt_orderby %]</b> ([% IF cmt_orderdir == 'DESC' %]descending[% ELSE %]ascending[% END %])</div>
+              [% END %]
               [% PROCESS _comments_table.tt comments = comments type='host' names=0 sortprefix='_cmt' %]
             [% END %]
           [% END %]
@@ -468,7 +470,9 @@
               </tr>
             </table>
             [% IF downtimes.size > 0 %]
+              [% IF sortoption_dtm %]
               <div class="statusSort" align="CENTER">Downtimes sorted by <b>[% dtm_orderby %]</b> ([% IF dtm_orderdir == 'DESC' %]descending[% ELSE %]ascending[% END %])</div>
+              [% END %]
               [% PROCESS _downtimes_table.tt downtimes = downtimes type='host' names=0 sortprefix='_dtm' %]
             [% END %]
             [% IF recurring_downtimes.size > 0 && use_feature_recurring_downtime %]

--- a/templates/extinfo_type_2.tt
+++ b/templates/extinfo_type_2.tt
@@ -433,7 +433,9 @@
               </tr>
             </table>
             [% IF comments.size > 0 %]
+              [% IF sortoption_cmt %]
               <div class="statusSort" align="CENTER">Comments sorted by <b>[% cmt_orderby %]</b> ([% IF cmt_orderdir == 'DESC' %]descending[% ELSE %]ascending[% END %])</div>
+              [% END %]
               [% PROCESS _comments_table.tt comments = comments type='service' names=0 sortprefix='_cmt' %]
             [% END %]
           [% END %]
@@ -466,7 +468,9 @@
               </tr>
             </table>
             [% IF downtimes.size > 0 %]
+              [% IF sortoption_dtm %]
               <div class="statusSort" align="CENTER">Downtimes sorted by <b>[% dtm_orderby %]</b> ([% IF dtm_orderdir == 'DESC' %]descending[% ELSE %]ascending[% END %])</div>
+              [% END %]
               [% PROCESS _downtimes_table.tt downtimes = downtimes type='service' names=0 sortprefix='_dtm' %]
             [% END %]
             [% IF recurring_downtimes.size > 0 && use_feature_recurring_downtime %]

--- a/templates/extinfo_type_3.tt
+++ b/templates/extinfo_type_3.tt
@@ -22,12 +22,13 @@
 
     <a name="HOSTCOMMENTS" id="HOSTCOMMENTS"></a>
     <div class='commentTitle'>Host Comments</div>
-    <div class='comment'>
-      [% UNLESS c.config.command_disabled.exists('1') || c.check_user_roles_wrapper('authorized_for_read_only') %]
-      <img src='[% url_prefix %]themes/[% theme %]/images/comment.gif' border="0" alt="#########" width="20" height="20">&nbsp;<a href='cmd.cgi?cmd_typ=1'>Add a new host comment</a>
-      [% END %]
-    </div><br>
+    [% UNLESS c.config.command_disabled.exists('1') || c.check_user_roles_wrapper('authorized_for_read_only') %]
+    <div class='comment'><img src='[% url_prefix %]themes/[% theme %]/images/comment.gif' border="0" alt="#########" width="20" height="20">&nbsp;<a href='cmd.cgi?cmd_typ=1'>Add a new host comment</a></div>
+    [% END %]
+    <br>
+    [% IF sortoption_hst %]
     <div class="statusSort" align="CENTER">Host comments sorted by <b>[% hst_orderby %]</b> ([% IF hst_orderdir == 'DESC' %]descending[% ELSE %]ascending[% END %])</div>
+    [% END %]
     <div align="center">
     <table border=0 cellpadding=0 cellspacing=0>
       <tr>
@@ -55,12 +56,13 @@
     <br>
     <a name="SERVICECOMMENTS" id="SERVICECOMMENTS"></a>
     <div class='commentTitle'>Service Comments</div>
-    <div class='comment'>
     [% UNLESS c.config.command_disabled.exists('3') || c.check_user_roles_wrapper('authorized_for_read_only') %]
-    <img src='[% url_prefix %]themes/[% theme %]/images/comment.gif' border="0" alt="#########" width="20" height="20">&nbsp;<a href='cmd.cgi?cmd_typ=3'>Add a new service comment</a>
+    <div class='comment'><img src='[% url_prefix %]themes/[% theme %]/images/comment.gif' border="0" alt="#########" width="20" height="20">&nbsp;<a href='cmd.cgi?cmd_typ=3'>Add a new service comment</a></div>
     [% END %]
-    </div><br>
+    <br>
+    [% IF sortoption_svc %]
     <div class="statusSort" align="CENTER">Service comments sorted by <b>[% svc_orderby %]</b> ([% IF svc_orderdir == 'DESC' %]descending[% ELSE %]ascending[% END %])</div>
+    [% END %]
     <div align="center" class="hint" style="padding: 4px;">Mark service comments with leftclick. Select multiple with shift + mouse.</div>
     [% PROCESS _comments_table.tt comments = servicecomments type='service' names=1 sortprefix='_svc' %]
 <br>

--- a/templates/extinfo_type_6.tt
+++ b/templates/extinfo_type_6.tt
@@ -21,9 +21,12 @@
     <a name="HOSTDOWNTIME" id="HOSTDOWNTIME"></a>
     <div class='downtimeTitle'>Scheduled Host Downtimes</div>
     [% UNLESS c.config.command_disabled.exists('55') || c.check_user_roles_wrapper('authorized_for_read_only') %]
-    <div class='comment'><img src='[% url_prefix %]themes/[% theme %]/images/downtime.gif' border="0" alt="#########" width="20" height="20">&nbsp;<a href='cmd.cgi?cmd_typ=55'>Schedule host downtime</a></div><br>
+    <div class='comment'><img src='[% url_prefix %]themes/[% theme %]/images/downtime.gif' border="0" alt="#########" width="20" height="20">&nbsp;<a href='cmd.cgi?cmd_typ=55'>Schedule host downtime</a></div>
     [% END %]
+    <br>
+    [% IF sortoption_hst %]
     <div class="statusSort" align="CENTER">Host downtimes sorted by <b>[% hst_orderby %]</b> ([% IF hst_orderdir == 'DESC' %]descending[% ELSE %]ascending[% END %])</div>
+    [% END %]
     <div align="center">
     <table border=0 cellpadding=0 cellspacing=0>
       <tr>
@@ -52,12 +55,13 @@
     <br>
     <a name="SERVICEDOWNTIME" id="SERVICEDOWNTIME"></a>
     <div class='downtimeTitle'>Scheduled Service Downtimes</div>
-    <div class='comment'>
     [% UNLESS c.config.command_disabled.exists('56') || c.check_user_roles_wrapper('authorized_for_read_only') %]
-    <img src='[% url_prefix %]themes/[% theme %]/images/downtime.gif' border="0" alt="#########" width="20" height="20">&nbsp;<a href='cmd.cgi?cmd_typ=56'>Schedule service downtime</a>
+    <div class='comment'><img src='[% url_prefix %]themes/[% theme %]/images/downtime.gif' border="0" alt="#########" width="20" height="20">&nbsp;<a href='cmd.cgi?cmd_typ=56'>Schedule service downtime</a></div>
     [% END %]
-    </div><br>
+    <br>
+    [% IF sortoption_svc %]
     <div class="statusSort" align="CENTER">Service downtimes sorted by <b>[% svc_orderby %]</b> ([% IF svc_orderdir == 'DESC' %]descending[% ELSE %]ascending[% END %])</div>
+    [% END %]
     <div align="center" class="hint" style="padding: 4px;">Mark service downtimes with leftclick. Select multiple with shift + mouse.</div>
     [% PROCESS _downtimes_table.tt downtimes = servicedowntimes type='service' names=1 sortprefix='_svc' %]
 <br>


### PR DESCRIPTION
This fixes a few things mainly adding the ability to sort the comments
and downtimes on the host and service pages. There were also a few style
changes I made as I saw fit along the way.

Mostly, the style changes were just wording tweaks, capitalization and
formatting. Added output to show current sorting method by default. This
may not be desired but I liked it so I kept it. Can remove it if people
do not like it.

Host comment sorting with sort method displayed:
![image](https://cloud.githubusercontent.com/assets/3237256/2633630/d3cec380-be70-11e3-9ef0-4080ae1906e3.png)

Service comments and downtime sorting with sort method displayed:

![image](https://cloud.githubusercontent.com/assets/3237256/2633641/f7cad152-be70-11e3-83d6-1b190a937de0.png)
![image](https://cloud.githubusercontent.com/assets/3237256/2633644/003b34b2-be71-11e3-99f1-6009a976ef25.png)

Downtimes page host portion with sort order displayed, fixed "downtime" to "downtimes" and capitalized "mark":
![image](https://cloud.githubusercontent.com/assets/3237256/2633655/2d1b1a6a-be71-11e3-952d-549f24edaa17.png)

Downtimes page service portion with sort order diplayed, fixed "downtime" to "downtimes" and added the "mark" line:
![image](https://cloud.githubusercontent.com/assets/3237256/2633664/4af04808-be71-11e3-9b72-f1b67a96a3c8.png)

Comments page host portion with sort order displayed:
![image](https://cloud.githubusercontent.com/assets/3237256/2633671/65900d74-be71-11e3-9d30-b53a8124064f.png)

Comments page service portion with sort order displayed and added the "mark" line:
![image](https://cloud.githubusercontent.com/assets/3237256/2633684/81f3fa20-be71-11e3-94fe-541d9f8163c3.png)
