### PR TITLE
Fixes to Exfoliation theme

### DIFF
--- a/themes/themes-available/Exfoliation/stylesheets/extinfo.css
+++ b/themes/themes-available/Exfoliation/stylesheets/extinfo.css
@@ -92,3 +92,16 @@ th.queue       { font-size: 9pt; text-align: center; padding: 0 3px 0 3px; backg
 .queueEven     { font-size: 9pt; background-color: #f4f2f2; padding: 0 4px 0 4px; }
 .queueENABLED  { font-size: 9pt; background-color: #88d066; border: 1px solid #777777; padding: 0 4px 0 4px; }
 .queueDISABLED { font-size: 9pt; background-color: #f88888; border: 1px solid #777777; padding: 0 4px 0 4px; }
+
+th.pnpSelected, th.dataSelected { background-color: #f0f1ee; border: 1px #444444 outset; font-size: 12px; }
+
+table.blockHeadBorder, div.blockHeadBorder {
+  background-color: #f0f1ee;
+  border: 1px #b2a0a0 outset;
+  text-align:center;
+  line-height: 18px;
+  height: 20px;
+  font-size: 16px;
+  font-weight: bold;
+  white-space: nowrap;
+}

--- a/themes/themes-available/Exfoliation/stylesheets/status.css
+++ b/themes/themes-available/Exfoliation/stylesheets/status.css
@@ -50,23 +50,23 @@ div.status   { font-size: 10pt; text-align: center; }
 div.serviceTotals      { font-size: 10pt; text-align: center; font-weight: bold; }
 table.serviceTotals    { font-size: 10pt; font-weight: bold; }
 th.serviceTotals,a.serviceTotals { font-size: 8pt; }
-th.serviceTotals       { font-size: 8pt; text-align: center; background-color: #e0e0e0; border: 1px solid #777777; padding: 2px 4px 2px 4px; }
-.serviceTotalsOK       { font-size: 8pt; text-align: center; background-color: #88d066; border: 1px solid #777777; padding: 2px 4px 2px 4px; }
-.serviceTotalsWARNING  { font-size: 8pt; text-align: center; background-color: #ffff00; border: 1px solid #777777; padding: 2px 4px 2px 4px; }
-.serviceTotalsUNKNOWN  { font-size: 8pt; text-align: center; background-color: #ffbb55; border: 1px solid #777777; padding: 2px 4px 2px 4px; }
-.serviceTotalsCRITICAL { font-size: 8pt; text-align: center; background-color: #f88888; border: 1px solid #777777; padding: 2px 4px 2px 4px; }
-.serviceTotalsPENDING  { font-size: 8pt; text-align: center; background-color: #acacac; border: 1px solid #777777; padding: 2px 4px 2px 4px; }
-.serviceTotalsPROBLEMS { font-size: 8pt; text-align: center; background-color: #aaccff; border: 1px solid #777777; padding: 2px 4px 2px 4px; }
+td.serviceTotals       { font-size: 8pt; text-align: center; background-color: #e0e0e0; border: 1px solid #777777; }
+.serviceTotalsOK       { font-size: 8pt; text-align: center; background-color: #88d066; border: 1px solid #777777; }
+.serviceTotalsWARNING  { font-size: 8pt; text-align: center; background-color: #ffff00; border: 1px solid #777777; }
+.serviceTotalsUNKNOWN  { font-size: 8pt; text-align: center; background-color: #ffbb55; border: 1px solid #777777; }
+.serviceTotalsCRITICAL { font-size: 8pt; text-align: center; background-color: #f88888; border: 1px solid #777777; }
+.serviceTotalsPENDING  { font-size: 8pt; text-align: center; background-color: #acacac; border: 1px solid #777777; }
+.serviceTotalsPROBLEMS { font-size: 8pt; text-align: center; background-color: #aaccff; border: 1px solid #777777; }
 
 div.hostTotals         { font-size: 10pt; text-align: center; font-weight: bold; }
 table.hostTotals       { font-size: 10pt; font-weight: bold; }
 th.hostTotals,a.hostTotals { font-size: 8pt; }
-td.hostTotals          { font-size: 8pt; text-align: center; background-color: #e0e0e0; border: 1px solid #777777; padding: 2px 4px 2px 4px; }
-.hostTotalsUP          { font-size: 8pt; text-align: center; background-color: #88d066; border: 1px solid #777777; padding: 2px 4px 2px 4px; }
-.hostTotalsDOWN        { font-size: 8pt; text-align: center; background-color: #f88888; border: 1px solid #777777; padding: 2px 4px 2px 4px; }
-.hostTotalsUNREACHABLE { font-size: 8pt; text-align: center; background-color: #ffbb55; border: 1px solid #777777; padding: 2px 4px 2px 4px; }
-.hostTotalsPENDING     { font-size: 8pt; text-align: center; background-color: #acacac; border: 1px solid #777777; padding: 2px 4px 2px 4px; }
-.hostTotalsPROBLEMS    { font-size: 8pt; text-align: center; background-color: #aaccff; border: 1px solid #777777; padding: 2px 4px 2px 4px; }
+td.hostTotals          { font-size: 8pt; text-align: center; background-color: #e0e0e0; border: 1px solid #777777; }
+.hostTotalsUP          { font-size: 8pt; text-align: center; background-color: #88d066; border: 1px solid #777777; }
+.hostTotalsDOWN        { font-size: 8pt; text-align: center; background-color: #f88888; border: 1px solid #777777; }
+.hostTotalsUNREACHABLE { font-size: 8pt; text-align: center; background-color: #ffbb55; border: 1px solid #777777; }
+.hostTotalsPENDING     { font-size: 8pt; text-align: center; background-color: #acacac; border: 1px solid #777777; }
+.hostTotalsPROBLEMS    { font-size: 8pt; text-align: center; background-color: #aaccff; border: 1px solid #777777; }
 
 .miniStatusPENDING     { font-size: 8pt; text-align: center; background-color: #acacac; border: 1px solid #777777; padding: 0 5px 0 5px; }
 .miniStatusOK          { font-size: 8pt; text-align: center; background-color: #88d066; border: 1px solid #777777; padding: 0 5px 0 5px; }


### PR DESCRIPTION
Fix typo I made when fixing the themes CSS readability. After fixing the
padding so that it got applied to most browsers I found some of it to be
ugly and prefer it didn't exist and look the way it did before when it was
broken.

Some style fixes around how the pnp4nagios graph image tables and their
borders are displayed.
