### PR TITLE
Fixes to Exfoliation theme

### DIFF
--- a/themes/themes-available/Exfoliation/stylesheets/Exfoliation.css
+++ b/themes/themes-available/Exfoliation/stylesheets/Exfoliation.css
@@ -46,3 +46,7 @@ td.filter { background-color: white; }
   line-height: 1.1;
   font-size: 0.85em;
 }
+
+table.cmd_pane { background: none; }
+table.cmd_pane tbody > tr > td { background: #f0f1ee; border: none; }
+table.cmd_pane th,table.cmd_pane a,table.cmd_pane a:hover { background: #f0f1ee; color: #333333; }


### PR DESCRIPTION
These changes are geared to the command popup that gets displayed on the hosts, services and downtimes pages when selecting multiple items. Fixes the header text not being visible and the background color of the popup being much darker than the rest of the theme.
