### PR TITLE
Fix perfdata human

### DIFF
--- a/templates/_perfdata_human.tt
+++ b/templates/_perfdata_human.tt
@@ -28,10 +28,10 @@
         [% END %]
         <td class="[% class %]" align="left">[% p.name %]</td>
         <td class="[% class %]" align="right" style="padding-right: 8px;">[% format_number(p.value) %][% p.unit %]</td>
-        [% IF has_warn %]<td class="[% class %]">[% p.warn %]</td>[% END %]
-        [% IF has_crit %]<td class="[% class %]">[% p.crit %]</td>[% END %]
-        [% IF has_min  %]<td class="[% class %]">[% p.min %]</td>[% END %]
-        [% IF has_max  %]<td class="[% class %]">[% p.max %]</td>[% END %]
+        [% IF has_warn %]<td class="[% class %]">[% format_number(p.warn) %]</td>[% END %]
+        [% IF has_crit %]<td class="[% class %]">[% format_number(p.crit) %]</td>[% END %]
+        [% IF has_min  %]<td class="[% class %]">[% format_number(p.min) %]</td>[% END %]
+        [% IF has_max  %]<td class="[% class %]">[% format_number(p.max) %]</td>[% END %]
         <td class="[% class %]">
           [% PROCESS _perfdata_table write="true" perfdata=p.orig state=0 %]
         </td>


### PR DESCRIPTION
Use `format_number()` on warning, critical, minimum and maximum. Doing it just on the actual value returned by the plugin does not look as good nor is it as helpful.

Before:

![before](https://cloud.githubusercontent.com/assets/3237256/4112179/42348582-321e-11e4-942e-98a2fca0e67e.PNG)

After:

![after](https://cloud.githubusercontent.com/assets/3237256/4112180/454989a2-321e-11e4-858e-93e381461de1.PNG)
