### PR TITLE
Fix comment ticket ssi

### DIFF
--- a/ssi/extinfo-header.ssi-tickets
+++ b/ssi/extinfo-header.ssi-tickets
@@ -1,7 +1,10 @@
 <script type="text/javascript">
 jQuery(document).ready(function() {
     jQuery("TABLE.comment, TABLE.downtime").each(function() {
-        var index = jQuery(this).find("th").filter(function() {
+        var headers = jQuery(this).find("th");
+        var count = headers.length;
+
+        var index = headers.filter(function() {
             return jQuery.trim(jQuery(this).text()) === "Comment";
         }).index();
 
@@ -9,9 +12,9 @@ jQuery(document).ready(function() {
             return;
         }
 
-        index++;
+        index = count - index;
 
-        jQuery(this).find("TD:nth-child(" + index + ")").each(function() {
+        jQuery(this).find("TD:nth-last-child(" + index + ")").each(function() {
             jQuery(this).html(jQuery(this).html().replace(/(\b\d{6}\b)/g, "<a href='http://example.com?ticket=$1' target='_blank'>$1</a>"));
         });
     });


### PR DESCRIPTION
Add support for recurring downtimes page

The recurring downtime page is much trickier than the other pages
because an extra column will be added depending on whether a host or
service is displayed.

The way around this problem is instead of counting from the first child
forward from the column index that was found, count backward from the
end where no extra rows will be added.

This works in Chrome, Firefox and Safari consistantly. There are some
issues with IE. Support for 'nth-last-child' came in IE9. Tests showed
this works as long as IE9 or greater is in use. However, Thruk currently
sends a `X-UA-Compatible` header specifying IE8 which breaks this unless
overridden by the user.

https://github.com/sni/Thruk/search?utf8=%E2%9C%93&q=X-UA-Compatible
