### PR TITLE
Fix parse error when not using new command box

### DIFF
--- a/templates/_service_command_box_full.tt
+++ b/templates/_service_command_box_full.tt
@@ -56,7 +56,6 @@
                 <td><img src='[% url_prefix %]themes/[% theme %]/images/disabled.gif' border="0" alt='Stop Accepting Passive Checks For This Service' title='Stop Accepting Passive Checks For This Service' width="20" height="20"></td>
                 <td class='command' nowrap><a href='cmd.cgi?cmd_typ=40&amp;host=[% service.host_name | uri %]&amp;service=[% service.description | uri %]&amp;backend=[% service.peer_key %]'>Stop accepting passive checks for this service</a></td>
               </tr>
-              [% END %]
               [% ELSE %]
               [% UNLESS c.config.command_disabled.exists('39') %]
               <tr class='command'>


### PR DESCRIPTION
After turning off the new command box and trying to render a service the
following error was presented in the Thruk log:

Couldn't render template "extinfo_type_2.tt: file error - parse error -
_service_command_box_full.tt line 60: unexpected token (ELSE)
