### PR TITLE
Fix reschedule check forced onto next line

### DIFF
--- a/templates/_host_command_box.tt
+++ b/templates/_host_command_box.tt
@@ -23,7 +23,7 @@
                 <td><img src='[% url_prefix %]themes/[% theme %]/images/delay.gif' border="0" alt='Re-schedule Next Host Check' title='Re-schedule Next Host Check' width="20" height="20"></td>
                 <td class='command'>
                   <a href='cmd.cgi?cmd_typ=96&amp;host=[% host.name | uri %]&amp;backend=[% host.peer_key %]'>Re-schedule next check of this host</a>
-                  (<form action='cmd.cgi' method='POST' style="display: inline;">
+                  <form action='cmd.cgi' method='POST' style="display: inline;">
                     <input type='hidden' name='cmd_typ' value='96'>
                     <input type='hidden' name='cmd_mod' value='2'>
                     <input type='hidden' name='start_time' value='[% date.now %]'>
@@ -32,8 +32,8 @@
                     <input type='hidden' name='backend' value='[% host.peer_key %]'>
                     <input type='hidden' name='referer' value='[% short_uri(c, {referer => 'undef'}) %]'>
                     <input type="hidden" name="token" value="[% get_user_token(c) %]">
-                    <a href='cmd.cgi?cmd_typ=96&amp;start_time=[% date.now %]&amp;host=[% host.name | uri %]&amp;force_check=1&amp;backend=[% host.peer_key %]&amp;referer=[% as_url_arg(short_uri(c, {referer => 'undef'})) %]' onClick="jQuery(this).closest('FORM').submit(); return false;"> Now </a>
-                  </form>)
+                    (<a href='cmd.cgi?cmd_typ=96&amp;start_time=[% date.now %]&amp;host=[% host.name | uri %]&amp;force_check=1&amp;backend=[% host.peer_key %]&amp;referer=[% as_url_arg(short_uri(c, {referer => 'undef'})) %]' onClick="jQuery(this).closest('FORM').submit(); return false;">Now</a>)
+                  </form>
                 </td>
               </tr>
               [% END %]

--- a/templates/_host_command_box_full.tt
+++ b/templates/_host_command_box_full.tt
@@ -32,7 +32,7 @@
                 <td><img src='[% url_prefix %]themes/[% theme %]/images/delay.gif' border="0" alt='Re-schedule Next Host Check' title='Re-schedule Next Host Check' width="20" height="20"></td>
                 <td class='command'>
                   <a href='cmd.cgi?cmd_typ=96&amp;host=[% host.name | uri %]&amp;backend=[% host.peer_key %]'>Re-schedule next check of this host</a>
-                  (<form action='cmd.cgi' method='POST' style="display: inline;">
+                  <form action='cmd.cgi' method='POST' style="display: inline;">
                     <input type='hidden' name='cmd_typ' value='96'>
                     <input type='hidden' name='cmd_mod' value='2'>
                     <input type='hidden' name='start_time' value='[% date.now %]'>
@@ -41,8 +41,8 @@
                     <input type='hidden' name='backend' value='[% host.peer_key %]'>
                     <input type='hidden' name='referer' value='[% short_uri(c, {referer => 'undef'}) %]'>
                     <input type="hidden" name="token" value="[% get_user_token(c) %]">
-                    <a href='cmd.cgi?cmd_typ=96&amp;start_time=[% date.now %]&amp;host=[% host.name | uri %]&amp;force_check=1&amp;backend=[% host.peer_key %]&amp;referer=[% as_url_arg(short_uri(c, {referer => 'undef'})) %]' onClick="jQuery(this).closest('FORM').submit(); return false;"> Now </a>
-                  </form>)
+                    (<a href='cmd.cgi?cmd_typ=96&amp;start_time=[% date.now %]&amp;host=[% host.name | uri %]&amp;force_check=1&amp;backend=[% host.peer_key %]&amp;referer=[% as_url_arg(short_uri(c, {referer => 'undef'})) %]' onClick="jQuery(this).closest('FORM').submit(); return false;">Now</a>)
+                  </form>
                 </td>
               </tr>
               [% END %]

--- a/templates/_service_command_box.tt
+++ b/templates/_service_command_box.tt
@@ -14,7 +14,7 @@
                 <td><img src='[% url_prefix %]themes/[% theme %]/images/delay.gif' border="0" alt='Re-schedule Next Service Check' title='Re-schedule Next Service Check' width="20" height="20"></td>
                 <td class='command'>
                   <a href='cmd.cgi?cmd_typ=7&amp;host=[% service.host_name | uri %]&amp;service=[% service.description | uri %]&amp;backend=[% service.peer_key %]'>Re-schedule next check of this service</a>
-                  (<form action='cmd.cgi' method='POST' style="display: inline;">
+                  <form action='cmd.cgi' method='POST' style="display: inline;">
                     <input type='hidden' name='cmd_typ' value='7'>
                     <input type='hidden' name='cmd_mod' value='2'>
                     <input type='hidden' name='start_time' value='[% date.now %]'>
@@ -24,8 +24,8 @@
                     <input type='hidden' name='backend' value='[% service.peer_key %]'>
                     <input type='hidden' name='referer' value='[% short_uri(c, {referer => 'undef'}) %]'>
                     <input type="hidden" name="token" value="[% get_user_token(c) %]">
-                    <a href='cmd.cgi?cmd_typ=7&amp;&amp;start_time=[% date.now %]&amp;host=[% service.host_name | uri %]&amp;service=[% service.description | uri %]&amp;force_check=1&amp;backend=[% service.peer_key %]&amp;referer=[% as_url_arg(short_uri(c, {referer => 'undef'})) %]' onClick="jQuery(this).closest('FORM').submit(); return false;"> Now </a>
-                  </form>)
+                    (<a href='cmd.cgi?cmd_typ=7&amp;&amp;start_time=[% date.now %]&amp;host=[% service.host_name | uri %]&amp;service=[% service.description | uri %]&amp;force_check=1&amp;backend=[% service.peer_key %]&amp;referer=[% as_url_arg(short_uri(c, {referer => 'undef'})) %]' onClick="jQuery(this).closest('FORM').submit(); return false;">Now</a>)
+                  </form>
                 </td>
               </tr>
               [% END %]

--- a/templates/_service_command_box_full.tt
+++ b/templates/_service_command_box_full.tt
@@ -27,7 +27,7 @@
                 <td><img src='[% url_prefix %]themes/[% theme %]/images/delay.gif' border="0" alt='Re-schedule Next Service Check' title='Re-schedule Next Service Check' width="20" height="20"></td>
                 <td class='command'>
                   <a href='cmd.cgi?cmd_typ=7&amp;host=[% service.host_name | uri %]&amp;service=[% service.description | uri %]&amp;backend=[% service.peer_key %]'>Re-schedule next check of this service</a>
-                  (<form action='cmd.cgi' method='POST' style="display: inline;">
+                  <form action='cmd.cgi' method='POST' style="display: inline;">
                     <input type='hidden' name='cmd_typ' value='7'>
                     <input type='hidden' name='cmd_mod' value='2'>
                     <input type='hidden' name='start_time' value='[% date.now %]'>
@@ -37,8 +37,8 @@
                     <input type='hidden' name='backend' value='[% service.peer_key %]'>
                     <input type='hidden' name='referer' value='[% short_uri(c, {referer => 'undef'}) %]'>
                     <input type="hidden" name="token" value="[% get_user_token(c) %]">
-                    <a href='cmd.cgi?cmd_typ=7&amp;&amp;start_time=[% date.now %]&amp;host=[% service.host_name | uri %]&amp;service=[% service.description | uri %]&amp;force_check=1&amp;backend=[% service.peer_key %]&amp;referer=[% as_url_arg(short_uri(c, {referer => 'undef'})) %]' onClick="jQuery(this).closest('FORM').submit(); return false;"> Now </a>
-                  </form>)
+                    (<a href='cmd.cgi?cmd_typ=7&amp;&amp;start_time=[% date.now %]&amp;host=[% service.host_name | uri %]&amp;service=[% service.description | uri %]&amp;force_check=1&amp;backend=[% service.peer_key %]&amp;referer=[% as_url_arg(short_uri(c, {referer => 'undef'})) %]' onClick="jQuery(this).closest('FORM').submit(); return false;">Now</a>)
+                  </form>
                 </td>
               </tr>
               [% END %]

--- a/themes/themes-available/Neat/stylesheets/extinfo.css
+++ b/themes/themes-available/Neat/stylesheets/extinfo.css
@@ -130,10 +130,6 @@ TABLE.command TR.command TD, TABLE.command TR.data TD {
 }
 TABLE.command TR.command TD.command, TABLE.command TR.data TD.command {
 }
-TD.command A {
- display: block;
- padding: 0.1em 0.5em 0.1em 0.5em;
-}
 TD.command A:hover {
  background-color: #FFFFCC;
 }


### PR DESCRIPTION
In many of the themes the "Re-schedule next check of this service" was
getting pushed onto the next line. In most cases just shortening the
length of the string seemed to do the trick. Removing the space between
'Now' and the parenthesis seemed appropriate. There are other links in
Thruk (the link box is a good example) where links are encapsulated in
parenthesis and there is no space seperating them.

In the case of the Neat theme some additional CSS changes were needed.
