### PR TITLE
Add the icon to the parent view

### DIFF
--- a/plugins/plugins-available/statusmap/lib/Thruk/Controller/statusmap.pm
+++ b/plugins/plugins-available/statusmap/lib/Thruk/Controller/statusmap.pm
@@ -549,6 +549,12 @@ sub _get_json_host {
             'state_pending'     => $state_pending,
         },
     };
+    if (defined $host->{'icon_image'}) {
+           my $icon_image = $host->{'icon_image'};
+           $icon_image =~ s/"//gmx;
+           $icon_image =~ s/'//gmx;
+           $json_host->{'data'}->{'icon_image'} = $icon_image;
+    }
     $self->{'all_nodes'}->{$host->{'name'}} = 1;
 
     return $json_host;

--- a/plugins/plugins-available/statusmap/root/Treemap.css
+++ b/plugins/plugins-available/statusmap/root/Treemap.css
@@ -32,6 +32,10 @@ html, body {
     padding:7px;
 }
 
+.tip .tip-icon {
+       float: right;
+}
+
 DIV.hostPENDING, SPAN.hostPENDING {
   font-weight: normal;
   font-size:10px;

--- a/plugins/plugins-available/statusmap/root/statusmap.js
+++ b/plugins/plugins-available/statusmap/root/statusmap.js
@@ -1,6 +1,9 @@
 /* create tool tip content */
 function makeHTMLFromData(name, data){
   var html = '';
+  if (data.icon_image != undefined) {
+    html += '<img class="tip-icon" src="../../check_mk/images/icons/' + data.icon_image + '" />';
+  }
   if(data.status != undefined) {
     // real host leaf
     html += '<div class="tip-title">Host: ' + name + '<\/div>'


### PR DESCRIPTION
The icon of the host is show on the popup page when you mouseover a host
point in the parent view.
