### PR TITLE
Add ability to generate URL for excel export

### DIFF
--- a/templates/_excel_export.tt
+++ b/templates/_excel_export.tt
@@ -83,7 +83,7 @@
                   [% IF style != 'combined' %]
                   <input type="button" value="create url" onclick="data = jQuery(this).parents('FORM').find('input[name=columns]').serialize(); jQuery('#excel_export_url').val(location.pathname + (location.search ? location.search + '&' : '?') + 'view_mode=xls' + (data ? '&' + data : ''));">
                   [% ELSE %]
-                  <input type="button" value="create url" onclick="jQuery('#view_mode').val('xls'); data = jQuery(this).parents('FORM').serialize(); jQuery('#excel_export_url').val(location.pathname + (data ? '?' + data : ''));">
+                  <input type="button" value="create url" onclick="jQuery('#view_mode').val('xls'); data = jQuery(this).parents('FORM').find('input[name!=bookmark][name!=referer]').serialize(); jQuery('#excel_export_url').val(location.pathname + (data ? '?' + data : ''));">
                   [% END %]
                 </td>
               </tr>


### PR DESCRIPTION
Create new button and input box to help create a URL for an excel export
that includes the selected columns.

Previously, one would have to look at their web server logs for the URL.

First attempt was to try and do this by opening the export in a new
winodow/tab but it seems most browsers (Chrome and FF atleast) will
cloes that tab immediately after the excel sheet was downloaded.

This lead to the URL itself being generated by the user once they are
happy with the options they have selected for their export.
