### PR TITLE
Slight clarifications around action_menu_actions

### DIFF
--- a/docs/documentation/configuration.asciidoc
+++ b/docs/documentation/configuration.asciidoc
@@ -1520,14 +1520,14 @@ of the script and the corresponding command. The command has to be a full path p
 and *not* just a shell command. Therefor you do not have to use quotes because the arguments
 are not interpreted by a shell before execution due to security reasons.
 
-It is possible to use most standard macros and the username is available in the `REMOTE_USER`
+It is possible to use most standard link:macros.html[Macros] and the username is available in the `REMOTE_USER`
 environment variable.
 
 ex.:
 
   <action_menu_actions>
-      example_action   = /usr/local/bin/sample.sh $HOSTNAME$ $SERVICEDESC$
-      refresh_action   = /usr/local/bin/refresh.sh otherargs
+      example   = /usr/local/bin/sample.sh $HOSTNAME$ $SERVICEDESC$
+      refresh   = /usr/local/bin/refresh.sh otherargs
   </action_menu_actions>
 
 

--- a/thruk.conf
+++ b/thruk.conf
@@ -790,8 +790,8 @@ cookie_auth_session_cache_timeout = 5
 </action_menu_items>
 
 <action_menu_actions>
-    #example_action   = /usr/local/bin/sample.sh $HOSTNAME$ $SERVICEDESC$
-    #refresh_action   = /usr/local/bin/refresh.sh otherargs
+    #example   = /usr/local/bin/sample.sh $HOSTNAME$ $SERVICEDESC$
+    #refresh   = /usr/local/bin/refresh.sh otherargs
 </action_menu_actions>
 
 <action_menu_apply>


### PR DESCRIPTION
The "_action" looked like a necessary postfix which it is not. Also,
added a link in the configuration page to the macros page so a user can
easily find what macros are available. This link already existed on the
"action-menu" page but not on the "configuration" page.