### PR TITLE
Fix host state by ID hash

### DIFF
--- a/lib/Thruk/Config.pm
+++ b/lib/Thruk/Config.pm
@@ -199,7 +199,7 @@ our %config = ('name'                   => 'Thruk',
                                     4 => 'PENDING',
                                 },
                   host_state_by_number => {
-                                    0 => 'OK',
+                                    0 => 'UP',
                                     1 => 'DOWN',
                                     2 => 'UNREACHABLE',
                                 },


### PR DESCRIPTION
The correct 'OK' state for a host is actually 'UP' according to the
majority of documentation out there including Thruk's own documentation
about macros which uses this hash table heavily for converting state
ID's to their equivalent string values.

http://thruk.org/documentation/macros.html#host-macros