### PR TITLE
Add 'expand_user_macros' option

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,10 +3,11 @@ This file documents the revision history for the Monitoring Webinterface Thruk.
 next:
           - add host and service notes url macros (Andrew Widdersheim)
           - add host and service duration macro (Andrew Widdersheim)
+          - add 'expand_user_macros' option (Andrew Widdersheim)
           - Panorama View:
             - add undo function
             - add fullscreen mode
-            - dashboard are now locked by default
+            - dashboards are now locked by default
             - fix showing -1 objects for new dashboards
             - fix showing empty totals for custom filter icons
           - Business Process:

--- a/docs/documentation/configuration.asciidoc
+++ b/docs/documentation/configuration.asciidoc
@@ -444,9 +444,13 @@ ex.:
   mode_dir = 0770
 
 === resource_file
-Set a general resource file. If used in combination with 'expand_user_macros'
-be aware that passwords could be exposed if configured to expand the wrong
-macros. Instead of using a general 'resource_file' you could define one file
+Set a general resource file.
+Be warned, if any macros contain sensitive data like passwords, setting
+this option could expose that data to unauthorized user. It is strongly
+recommended that this option is only used if no passwords are used in
+this file or in combination with the 'expand_user_macros' option which
+will limit which macros are exposed to the user.
+Instead of using a general 'resource_file' you could define one file
 per peer in your peer config.
 
 ex.:
@@ -762,8 +766,7 @@ ex.:
 Display the full command line for host / service checks .
 Be warned, the command line could contain passwords and other confidential data.
 In order to replace the user macros for commands, you have to set the
-'resource_file' in your peer config or the general 'resource_file' option and
-set 'expand_user_macros' to a safe set of macros to expand.
+'resource_file' in your peer config or a general resource_file option.
 
  * 0 = off, don't show the command line at all
  * 1 = show them for contacts with the role: authorized_for_configuration_information
@@ -926,15 +929,14 @@ ex.:
 === expand_user_macros
 Expand user macros ($USERx$) for host / service commands and custom
 variables. Can be specified more than once to define multiple user
-macros to expand. Specifiying 'ALL' will expand all $USERx$ macros.
+macros to expand.
 Be warned, some user macros can contain passwords and expanding them
-could expose them to unauthorized users.
+could expose them to unauthorized users. Use * as wildcard, ex.: _VAR*
 
 ex.:
 
-  expand_user_macros = $USER1$
-  expand_user_macros = $USER20$
-  expand_user_macros = ALL # expands all $USERx$ macros
+  expand_user_macros = USER1
+  expand_user_macros = PLUGIN*
 
 
 === show_error_reports

--- a/docs/documentation/configuration.asciidoc
+++ b/docs/documentation/configuration.asciidoc
@@ -444,10 +444,10 @@ ex.:
   mode_dir = 0770
 
 === resource_file
-Set a general resource file. Make sure it does not contain any
-passwords or any other data which should not be displayed. Instead of
-using a general 'resource_file' you could define one file per peer in your
-peer config.
+Set a general resource file. If used in combination with 'expand_user_macros'
+be aware that passwords could be exposed if configured to expand the wrong
+macros. Instead of using a general 'resource_file' you could define one file
+per peer in your peer config.
 
 ex.:
 
@@ -762,7 +762,8 @@ ex.:
 Display the full command line for host / service checks .
 Be warned, the command line could contain passwords and other confidential data.
 In order to replace the user macros for commands, you have to set the
-'resource_file' in your peer config or the general 'resource_file' option.
+'resource_file' in your peer config or the general 'resource_file' option and
+set 'expand_user_macros' to a safe set of macros to expand.
 
  * 0 = off, don't show the command line at all
  * 1 = show them for contacts with the role: authorized_for_configuration_information
@@ -920,6 +921,20 @@ variables. Use * as wildcard, ex.: _VAR*
 ex.:
 
   show_custom_vars = _VAR1
+
+
+=== expand_user_macros
+Expand user macros ($USERx$) for host / service commands and custom
+variables. Can be specified more than once to define multiple user
+macros to expand. Specifiying 'ALL' will expand all $USERx$ macros.
+Be warned, some user macros can contain passwords and expanding them
+could expose them to unauthorized users.
+
+ex.:
+
+  expand_user_macros = $USER1$
+  expand_user_macros = $USER20$
+  expand_user_macros = ALL # expands all $USERx$ macros
 
 
 === show_error_reports
@@ -1421,6 +1436,11 @@ Sample menu with two items and a seperator:
         "label":  "refresh",
         "action": "server://refresh/$HOSTNAME$"
       },
+      {
+        "icon":   "/thruk/themes/{{theme}}/images/page_white_key.png",
+        "label":  "example",
+        "action": "server://example/$HOSTNAME$/$SERVICEDESC$"
+      },
       "-",
       {
         "icon":   "/thruk/themes/{{theme}}/images/page_white_text.png",
@@ -1526,7 +1546,7 @@ environment variable.
 ex.:
 
   <action_menu_actions>
-      example   = /usr/local/bin/sample.sh $HOSTNAME$ $SERVICEDESC$
+      example   = /usr/local/bin/sample.sh $HOSTNAME$ $SERVICEDESC$ $USER20$
       refresh   = /usr/local/bin/refresh.sh otherargs
   </action_menu_actions>
 

--- a/lib/Thruk/Backend/Manager.pm
+++ b/lib/Thruk/Backend/Manager.pm
@@ -868,8 +868,9 @@ sub _get_macros {
     my $args    = shift;
     my $macros  = shift || {};
 
-    my $host    = $args->{'host'};
-    my $service = $args->{'service'};
+    my $host        = $args->{'host'};
+    my $service     = $args->{'service'};
+    my $filter_user = (defined $args->{'filter_user'}) ? $args->{'filter_user'} : 1;
 
     # arguments
     my $x = 1;
@@ -880,7 +881,7 @@ sub _get_macros {
 
     # user macros...
     unless(defined $args->{'skip_user'}) {
-        $self->_set_user_macros($host->{'peer_key'}, $macros);
+        $self->_set_user_macros({peer_key => $host->{'peer_key'}, filter => $filter_user}, $macros);
     }
 
     # host macros
@@ -944,10 +945,11 @@ returns a hash of macros
 
 $args should be:
 {
-    host      => host object (or service object)
-    service   => service object
-    skip_user => 0/1   # skips user macros
-    args      => list of arguments
+    host        => host object (or service object)
+    service     => service object
+    skip_user   => 0/1   # skips user macros
+    filter_user => 0/1   # filters user macros
+    args        => list of arguments
 }
 
 =cut
@@ -1048,8 +1050,8 @@ sub _set_host_macros {
     $macros->{'$HOSTBACKENDADDRESS$'} = '';
     my $peer = defined $host->{'peer_key'} ? $self->get_peer_by_key($host->{'peer_key'}) : undef;
     if($peer) {
-        $macros->{'$HOSTBACKENDNAME$'}    = (defined $peer->{'name'})             ? $peer->{'name'}                 : '';
-        $macros->{'$HOSTBACKENDADDRESS$'} = (defined $peer->{'addr'})             ? $peer->{'addr'}                 : '';
+        $macros->{'$HOSTBACKENDNAME$'}    = (defined $peer->{'name'}) ? $peer->{'name'} : '';
+        $macros->{'$HOSTBACKENDADDRESS$'} = (defined $peer->{'addr'}) ? $peer->{'addr'} : '';
     }
 
     my $prefix = (defined $host->{'host_custom_variable_names'}) ? 'host_' : '';
@@ -2290,23 +2292,37 @@ sub _limit {
 
 =head2 _set_user_macros
 
-  _set_user_macros($peer_key)
+  _set_user_macros($args, $macros)
 
-sets the USER1-256 macros from a resource file. Shinken supports all kind of
+Sets the USER1-256 macros from a resource file. Shinken supports all kind of
 macros in resource file, so just replace everything from the resource file.
+
+$args should be:
+{
+    peer_key      => peer key for the host
+    filter        => 0/1   # only add allowed macros
+    file          => location of resource file
+    args          => list of arguments
+}
 
 =cut
 
 sub _set_user_macros {
-    my($self, $peer_key, $macros, $file) = @_;
-    my $c = $Thruk::Backend::Manager::c;
+    my $self   = shift;
+    my $args   = shift;
+    my $macros = shift || {};
+    my $c      = $Thruk::Backend::Manager::c;
+
+    my $search = $args->{'search'} || 'expand_user_macros';
+    my $filter = (defined $args->{'filter'}) ? $args->{'filter'} : 1;
+    my $vars   = ref $c->config->{$search} eq 'ARRAY' ? $c->config->{$search} : [ $c->config->{$search} ];
 
     my $res;
-    if(defined $file) {
-        $res = Thruk::Utils::read_resource_file($file);
+    if(defined $args->{'file'}) {
+        $res = Thruk::Utils::read_resource_file($args->{'file'});
     }
-    if(!defined $res and defined $peer_key) {
-        my $backend = $self->get_peer_by_key($peer_key);
+    if(!defined $res and defined $args->{'peer_key'}) {
+        my $backend = $self->get_peer_by_key($args->{'peer_key'});
         if(defined $backend->{'resource_file'}) {
             $res = Thruk::Utils::read_resource_file($backend->{'resource_file'});
         }
@@ -2315,8 +2331,30 @@ sub _set_user_macros {
         $res = Thruk::Utils::read_resource_file($c->config->{'resource_file'});
     }
 
-    if(defined $res) {
+    for my $test (@$vars) {
+        if($test eq 'ALL') {
+            $filter = 0;
+            last;
+        }
+    }
+
+    if(defined $res and (!$filter or ($filter and scalar @$vars))) {
         for my $key (keys %{$res}) {
+            if($filter) {
+                my $found = 0;
+
+                for my $test (@$vars) {
+                    if($key eq $test) {
+                        $found = 1;
+                        last;
+                    }
+                }
+
+                if(!$found) {
+                    next;
+                }
+            }
+
             $macros->{$key} = $res->{$key};
         }
     }

--- a/lib/Thruk/Backend/Pool.pm
+++ b/lib/Thruk/Backend/Pool.pm
@@ -152,6 +152,7 @@ sub set_default_config {
         downtime_duration                   => 7200,
         expire_ack_duration                 => 86400,
         show_custom_vars                    => [],
+        expand_user_macros                  => [],
         themes_path                         => './themes',
         priorities                      => {
                     5                       => 'Business Critical',

--- a/lib/Thruk/Utils.pm
+++ b/lib/Thruk/Utils.pm
@@ -1012,15 +1012,17 @@ sub set_custom_vars {
                 if (defined $host and defined $service) {
                         #($cust_value, $rc)...
                         ($cust_value, undef) = $c->{'db'}->_replace_macros({
-                            string  => $cust_value,
-                            host    => $host,
-                            service => $service
+                            string      => $cust_value,
+                            host        => $host,
+                            service     => $service,
+                            filter_user => 1
                         });
                 } elsif (defined $host) {
                         #($cust_value, $rc)...
                         ($cust_value, undef) = $c->{'db'}->_replace_macros({
-                            string  => $cust_value,
-                            host    => $host
+                            string      => $cust_value,
+                            host        => $host,
+                            filter_user => 1
                         });
                 }
 

--- a/lib/Thruk/Utils/Status.pm
+++ b/lib/Thruk/Utils/Status.pm
@@ -1993,7 +1993,7 @@ sub serveraction {
         return(1, 'no such object') unless $obj;
     }
 
-    my $macros = $c->{'db'}->get_macros({host => $obj, service => $service ? $obj : undef, filter_user => 0});
+    my $macros = $c->{'db'}->get_macros({host => $obj, service => $service ? $obj : undef});
     $macros->{'$REMOTE_USER$'}    = $c->stash->{'remote_user'};
     $macros->{'$DASHBOARD_ID$'}   = $c->{'request'}->{'parameters'}->{'dashboard'} if $c->{'request'}->{'parameters'}->{'dashboard'};
     $macros->{'$DASHBOARD_ICON$'} = $c->{'request'}->{'parameters'}->{'icon'}      if $c->{'request'}->{'parameters'}->{'icon'};

--- a/lib/Thruk/Utils/Status.pm
+++ b/lib/Thruk/Utils/Status.pm
@@ -1993,7 +1993,7 @@ sub serveraction {
         return(1, 'no such object') unless $obj;
     }
 
-    my $macros = $c->{'db'}->get_macros({host => $obj, service => $service ? $obj : undef, skip_user => 1});
+    my $macros = $c->{'db'}->get_macros({host => $obj, service => $service ? $obj : undef, filter_user => 0});
     $macros->{'$REMOTE_USER$'}    = $c->stash->{'remote_user'};
     $macros->{'$DASHBOARD_ID$'}   = $c->{'request'}->{'parameters'}->{'dashboard'} if $c->{'request'}->{'parameters'}->{'dashboard'};
     $macros->{'$DASHBOARD_ICON$'} = $c->{'request'}->{'parameters'}->{'icon'}      if $c->{'request'}->{'parameters'}->{'icon'};

--- a/t/100-model_Thruk.t
+++ b/t/100-model_Thruk.t
@@ -136,6 +136,48 @@ is($cmd->{'line_expanded'}, '/tmp/check_test ', 'expanded command: '.$cmd->{'lin
 is($cmd->{'note'}, '', 'note should be empty');
 
 ################################################################################
+# set expand user macros
+$b->{'config'}->{'expand_user_macros'} = ["NONE"]
+$cmd = $b->expand_command(
+    'host'    => $hosts->[0],
+    'command' => {
+        'name' => 'check_test',
+        'line' => '$PLUGINDIR$/check_test -H $HOSTNAME$ -p $USER2$'
+    },
+);
+is($cmd->{'line_expanded'}, '$PLUGINDIR$/check_test -H '.$hosts->[0]->{'name'}.' -p $USER2$', 'expanded command: '.$cmd->{'line_expanded'});
+is($cmd->{'line'}, $hosts->[0]->{'check_command'}, 'host command is: '.$hosts->[0]->{'check_command'});
+is($cmd->{'note'}, '', 'note should be empty');
+
+################################################################################
+# set expand user macros
+$b->{'config'}->{'expand_user_macros'} = ["PLUGINDIR"]
+$cmd = $b->expand_command(
+    'host'    => $hosts->[0],
+    'command' => {
+        'name' => 'check_test',
+        'line' => '$PLUGINDIR$/check_test -H $HOSTNAME$ -p $USER2$'
+    },
+);
+is($cmd->{'line_expanded'}, '/usr/local/plugins/check_test -H '.$hosts->[0]->{'name'}.' -p $USER2$', 'expanded command: '.$cmd->{'line_expanded'});
+is($cmd->{'line'}, $hosts->[0]->{'check_command'}, 'host command is: '.$hosts->[0]->{'check_command'});
+is($cmd->{'note'}, '', 'note should be empty');
+
+################################################################################
+# set expand user macros
+$b->{'config'}->{'expand_user_macros'} = ["PLUGINDIR", "USER*"]
+$cmd = $b->expand_command(
+    'host'    => $hosts->[0],
+    'command' => {
+        'name' => 'check_test',
+        'line' => '$PLUGINDIR$/check_test -H $HOSTNAME$ -p $USER2$'
+    },
+);
+is($cmd->{'line_expanded'}, '/usr/local/plugins/check_test -H '.$hosts->[0]->{'name'}.' -p test3', 'expanded command: '.$cmd->{'line_expanded'});
+is($cmd->{'line'}, $hosts->[0]->{'check_command'}, 'host command is: '.$hosts->[0]->{'check_command'});
+is($cmd->{'note'}, '', 'note should be empty');
+
+################################################################################
 my $res1 = Thruk::Utils::read_resource_file('t/data/resource.cfg');
 my $res2 = Thruk::Utils::read_resource_file('t/data/resource2.cfg');
 is_deeply($res1, $res2, 'parsing resource.cfg');

--- a/t/100-model_Thruk.t
+++ b/t/100-model_Thruk.t
@@ -137,7 +137,7 @@ is($cmd->{'note'}, '', 'note should be empty');
 
 ################################################################################
 # set expand user macros
-$b->{'config'}->{'expand_user_macros'} = ["NONE"]
+$b->{'config'}->{'expand_user_macros'} = ["NONE"];
 $cmd = $b->expand_command(
     'host'    => $hosts->[0],
     'command' => {
@@ -151,7 +151,7 @@ is($cmd->{'note'}, '', 'note should be empty');
 
 ################################################################################
 # set expand user macros
-$b->{'config'}->{'expand_user_macros'} = ["PLUGINDIR"]
+$b->{'config'}->{'expand_user_macros'} = ["PLUGINDIR"];
 $cmd = $b->expand_command(
     'host'    => $hosts->[0],
     'command' => {
@@ -165,7 +165,7 @@ is($cmd->{'note'}, '', 'note should be empty');
 
 ################################################################################
 # set expand user macros
-$b->{'config'}->{'expand_user_macros'} = ["PLUGINDIR", "USER*"]
+$b->{'config'}->{'expand_user_macros'} = ["PLUGINDIR", "USER*"];
 $cmd = $b->expand_command(
     'host'    => $hosts->[0],
     'command' => {

--- a/t/100-model_Thruk.t
+++ b/t/100-model_Thruk.t
@@ -9,7 +9,7 @@ $Data::Dumper::Sortkeys = 1;
 BEGIN {
     plan skip_all => 'internal test only' if defined $ENV{'CATALYST_SERVER'};
     plan skip_all => 'backends required' if(!-s 'thruk_local.conf' and !defined $ENV{'CATALYST_SERVER'});
-    plan tests => 30;
+    plan tests => 37;
 }
 
 BEGIN {

--- a/t/100-model_Thruk.t
+++ b/t/100-model_Thruk.t
@@ -147,7 +147,6 @@ $cmd = $b->expand_command(
 );
 is($cmd->{'line_expanded'}, '$PLUGINDIR$/check_test -H '.$hosts->[0]->{'name'}.' -p $USER2$', 'expanded command: '.$cmd->{'line_expanded'});
 is($cmd->{'line'}, $hosts->[0]->{'check_command'}, 'host command is: '.$hosts->[0]->{'check_command'});
-is($cmd->{'note'}, '', 'note should be empty');
 
 ################################################################################
 # set expand user macros
@@ -161,7 +160,6 @@ $cmd = $b->expand_command(
 );
 is($cmd->{'line_expanded'}, '/usr/local/plugins/check_test -H '.$hosts->[0]->{'name'}.' -p $USER2$', 'expanded command: '.$cmd->{'line_expanded'});
 is($cmd->{'line'}, $hosts->[0]->{'check_command'}, 'host command is: '.$hosts->[0]->{'check_command'});
-is($cmd->{'note'}, '', 'note should be empty');
 
 ################################################################################
 # set expand user macros

--- a/thruk.conf
+++ b/thruk.conf
@@ -291,7 +291,7 @@ show_backends_in_table=0
 # and other confidential data.
 # In order to replace the user macros for commands, you have to set
 # the 'resource_file' in your peer config or a general resource_file
-# option and set 'expand_user_macros' to a safe set of macros to expand.
+# option.
 # See the next option.
 # 0 = off, don't show the command line at all
 # 1 = show them for all with the role: authorized_for_configuration_information
@@ -305,8 +305,12 @@ show_full_commandline = 1
 # 'show_full_commandline_source' to '_CUST_VAR_NAME'.
 show_full_commandline_source = check_command
 
-# Set a general resource file. If used in combination with 'expand_user_macros'
-# be aware that passwords could be exposed if configured to expand the wrong macros.
+# Set a general resource file.
+# Be warned: if any macros contain sensitive data like passwords, setting
+# this option could expose that data to unauthorized user. It is strongly
+# recommended that this option is only used if no passwords are used in
+# this file or in combination with the 'expand_user_macros' option which
+# will limit which macros are exposed to the user.
 # Instead of using a general resource_file, you could define one file
 # per peer in your peer config.
 #
@@ -349,14 +353,13 @@ shown_inline_pnp = 1
 # Expand user macros ($USERx$) for host / service
 # commands and custom variables.
 # Can be specified more than once to define multiple
-# user macros to expand. Specifiying 'ALL' will expand
-# all $USERx$ macros.
+# user macros to expand.
 # Be warned: some user macros can contain passwords
 # and expanding them could expose them to unauthorized
 # users.
-#expand_user_macros = $USER1$
-#expand_user_macros = $USER2$
-#expand_user_macros = ALL # expands all $USERx$ macros
+# Use * as wildcard, ex.: _VAR*
+#expand_user_macros = USER1
+#expand_user_macros = PLUGIN*
 
 
 # show if a host / service has modified attributes.

--- a/thruk.conf
+++ b/thruk.conf
@@ -291,7 +291,8 @@ show_backends_in_table=0
 # and other confidential data.
 # In order to replace the user macros for commands, you have to set
 # the 'resource_file' in your peer config or a general resource_file
-# option. See the next option.
+# option and set 'expand_user_macros' to a safe set of macros to expand.
+# See the next option.
 # 0 = off, don't show the command line at all
 # 1 = show them for all with the role: authorized_for_configuration_information
 # 2 = show them for everyone
@@ -304,9 +305,8 @@ show_full_commandline = 1
 # 'show_full_commandline_source' to '_CUST_VAR_NAME'.
 show_full_commandline_source = check_command
 
-# set a general resource file. Make sure it does not
-# contain any passwords or any other data which should not be
-# displayed.
+# Set a general resource file. If used in combination with 'expand_user_macros'
+# be aware that passwords could be exposed if configured to expand the wrong macros.
 # Instead of using a general resource_file, you could define one file
 # per peer in your peer config.
 #
@@ -344,6 +344,20 @@ shown_inline_pnp = 1
 # Use * as wildcard, ex.: _VAR*
 #show_custom_vars = _VAR1
 #show_custom_vars = _VAR2
+
+
+# Expand user macros ($USERx$) for host / service
+# commands and custom variables.
+# Can be specified more than once to define multiple
+# user macros to expand. Specifiying 'ALL' will expand
+# all $USERx$ macros.
+# Be warned: some user macros can contain passwords
+# and expanding them could expose them to unauthorized
+# users.
+#expand_user_macros = $USER1$
+#expand_user_macros = $USER2$
+#expand_user_macros = ALL # expands all $USERx$ macros
+
 
 # show if a host / service has modified attributes.
 show_modified_attributes = 1
@@ -782,7 +796,7 @@ cookie_auth_session_cache_timeout = 5
     #       {\
     #           "icon": "/thruk/themes/{{theme}}/images/arrow_refresh.png",\
     #           "label": "Refresh",\
-    #           "action": "server://refresh/$SERVICEDESC$",\
+    #           "action": "server://refresh/$HOSTNAME/$SERVICEDESC$",\
     #           "target": "_blank"\
     #       },\
     #   ]\
@@ -790,7 +804,7 @@ cookie_auth_session_cache_timeout = 5
 </action_menu_items>
 
 <action_menu_actions>
-    #example   = /usr/local/bin/sample.sh $HOSTNAME$ $SERVICEDESC$
+    #example   = /usr/local/bin/sample.sh $HOSTNAME$ $SERVICEDESC$ $USER20$
     #refresh   = /usr/local/bin/refresh.sh otherargs
 </action_menu_actions>
 


### PR DESCRIPTION
With the addition of the new action menu capabilities to Thruk there is
an added need to allow $USERx$ macros to be expanded while still
limiting their exposure when a host/service command line or custom
variable is expanded.

The 'expand_user_macros' option allows for granular control over which
$USERx$ macros are expanded when the command line and custom variables
are expanded while still allowing server actions the ability to use any
$USERx$ macro.

This new option also still retains the ability of completely turn off
the expansion of all $USERx$ macros by just not specifying anything in
the configuration. To turn expansion on for all macros simply
specifiying 'ALL' will do the trick.

The comparison between the $USERx$ macros and the values supplied in
'expand_user_macros' is not currently capable of handling regular
expressions. This seemed a bit overkill but if there is a good value add
then it can certainly be changed to do so in the future.

Documentation was updated to reflect all of the changes including a few
clarifying changes to the action menu peices that show $USERx$ macros
are now supported and how to specify multiple arguments to server
actions.