### PR TITLE
Remove IE8 compatibility mode which fixes #416

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ This file documents the revision history for the Monitoring Webinterface Thruk.
 next:
           - add host and service notes url macros (Andrew Widdersheim)
           - add host and service duration macro (Andrew Widdersheim)
+          - disable IE8 compatiblity mode introduced in 56c92b1 (Andrew Widdersheim)
           - Panorama View:
             - add undo function
               - restore point can be created manually

--- a/templates/_header.tt
+++ b/templates/_header.tt
@@ -2,7 +2,6 @@
   "http://www.w3.org/TR/html4/strict.dtd">
 <html[% IF minimal %] class='minimal'[% END %]>
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=8"/>
     <title>[% title_prefix %][% title %]</title>
     <link rel="shortcut icon" href="[% url_prefix %]themes/[% theme %]/images/favicon.ico" type="image/ico" />
 

--- a/templates/index.tt
+++ b/templates/index.tt
@@ -2,7 +2,6 @@
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=8"/>
     <meta name="ROBOTS" content="NOINDEX, NOFOLLOW" />
     <title>[% title_prefix %][% title %]</title>
     <link rel="shortcut icon" href="[% url_prefix %]themes/[% theme %]/images/favicon.ico" type="image/ico" />


### PR DESCRIPTION
Stop Thruk from requesting IE8 compatibility mode. This was introduced
in 56c92b1 by @lingej (Joerg Linge) back in August of 2011 (over 3 years
ago) but it's unclear as to why.

A lot has changed in that time and hopefully whatever problem the
compatibilty mode was trying to solve has hopefully been rectified.
Getting rid of this has a lot of advantages to IE users (what little IE
users are left anyway). Most notably, the ability to use the latest and
greatest browser features introduced in newer versions of IE.

Some quick testing in IE didn't show any major issues.