### PR TITLE
Updates to expand user macros

### DIFF
--- a/docs/documentation/configuration.asciidoc
+++ b/docs/documentation/configuration.asciidoc
@@ -933,7 +933,7 @@ macros to expand.
 Be warned, some user macros can contain passwords and expanding them
 could expose them to unauthorized users. Use * as wildcard, ex.: USER*
 
-Defaults to USER1-255. So by default all user macros are expanded, because
+Defaults to 'ALL' which means all user macros are expanded, because
 its limited to admin users anyway.
 
 ex.:
@@ -941,6 +941,8 @@ ex.:
   expand_user_macros = USER1
   expand_user_macros = USER10-20
   expand_user_macros = PLUGIN*
+  expand_user_macros = ALL  # expands all user macros
+  expand_user_macros = NONE # do not expand user macros
 
 
 === show_error_reports

--- a/lib/Thruk/Backend/Manager.pm
+++ b/lib/Thruk/Backend/Manager.pm
@@ -2339,9 +2339,11 @@ sub _set_user_macros {
 
                 for my $test (@{$vars}) {
                     if($test eq 'ALL') {
-                        $found = 1;
+                        $filter = 0;
+                        $found  = 1;
                         last;
                     }
+
                     if($k eq $test) {
                         $found = 1;
                         last;

--- a/lib/Thruk/Backend/Manager.pm
+++ b/lib/Thruk/Backend/Manager.pm
@@ -600,7 +600,7 @@ sub expand_command {
 
     my $rc;
     eval {
-        ($expanded,$rc) = $self->_replace_macros({string => $expanded, host => $host, service => $service, args => \@com_args, filter_user => 1});
+        ($expanded,$rc) = $self->_replace_macros({string => $expanded, host => $host, service => $service, args => \@com_args});
     };
 
     # does it still contain macros?
@@ -870,7 +870,7 @@ sub _get_macros {
 
     my $host        = $args->{'host'};
     my $service     = $args->{'service'};
-    my $filter_user = (defined $args->{'filter_user'}) ? $args->{'filter_user'} : 0;
+    my $filter_user = (defined $args->{'filter_user'}) ? $args->{'filter_user'} : 1;
 
     # arguments
     my $x = 1;
@@ -2314,7 +2314,7 @@ sub _set_user_macros {
     my $c      = $Thruk::Backend::Manager::c;
 
     my $search = $args->{'search'} || 'expand_user_macros';
-    my $filter = (defined $args->{'filter'}) ? $args->{'filter'} : 0;
+    my $filter = (defined $args->{'filter'}) ? $args->{'filter'} : 1;
     my $vars   = ref $c->config->{$search} eq 'ARRAY' ? $c->config->{$search} : [ $c->config->{$search} ];
 
     my $res;

--- a/lib/Thruk/Backend/Manager.pm
+++ b/lib/Thruk/Backend/Manager.pm
@@ -2344,6 +2344,11 @@ sub _set_user_macros {
                         last;
                     }
 
+                    if($test eq 'NONE') {
+                        # return an empty hash
+                        return {};
+                    }
+
                     if($k eq $test) {
                         $found = 1;
                         last;

--- a/lib/Thruk/Utils.pm
+++ b/lib/Thruk/Utils.pm
@@ -1012,17 +1012,15 @@ sub set_custom_vars {
                 if (defined $host and defined $service) {
                         #($cust_value, $rc)...
                         ($cust_value, undef) = $c->{'db'}->_replace_macros({
-                            string      => $cust_value,
-                            host        => $host,
-                            service     => $service,
-                            filter_user => 1
+                            string  => $cust_value,
+                            host    => $host,
+                            service => $service
                         });
                 } elsif (defined $host) {
                         #($cust_value, $rc)...
                         ($cust_value, undef) = $c->{'db'}->_replace_macros({
-                            string      => $cust_value,
-                            host        => $host,
-                            filter_user => 1
+                            string  => $cust_value,
+                            host    => $host,
                         });
                 }
 

--- a/lib/Thruk/Utils/Status.pm
+++ b/lib/Thruk/Utils/Status.pm
@@ -1993,7 +1993,7 @@ sub serveraction {
         return(1, 'no such object') unless $obj;
     }
 
-    my $macros = $c->{'db'}->get_macros({host => $obj, service => $service ? $obj : undef});
+    my $macros = $c->{'db'}->get_macros({host => $obj, service => $service ? $obj : undef, filter_user => 0});
     $macros->{'$REMOTE_USER$'}    = $c->stash->{'remote_user'};
     $macros->{'$DASHBOARD_ID$'}   = $c->{'request'}->{'parameters'}->{'dashboard'} if $c->{'request'}->{'parameters'}->{'dashboard'};
     $macros->{'$DASHBOARD_ICON$'} = $c->{'request'}->{'parameters'}->{'icon'}      if $c->{'request'}->{'parameters'}->{'icon'};

--- a/thruk.conf
+++ b/thruk.conf
@@ -357,9 +357,15 @@ shown_inline_pnp = 1
 # Be warned: some user macros can contain passwords
 # and expanding them could expose them to unauthorized
 # users.
-# Use * as wildcard, ex.: _VAR*
+# Use * as wildcard, ex.: USER*
+#
+#Defaults to 'ALL' which means all user macros are expanded, because
+#its limited to admin users anyway.
 #expand_user_macros = USER1
+#expand_user_macros = USER10-20
 #expand_user_macros = PLUGIN*
+#expand_user_macros = ALL  # expands all user macros
+#expand_user_macros = NONE # do not expand user macros
 
 
 # show if a host / service has modified attributes.


### PR DESCRIPTION
Added new 'NONE' option to 'expand_user_macros'. Added documentation for both the 'ALL' and 'NONE' option. Added small performance improvement to `_set_user_macros()`. Enable user macro filtering by default in the code to help with security and readability. Updated documentation/examples in thruk.conf for changes including number ranges added in b9ac6d7d.