### PR TITLE
Add ability to display action menu title

### DIFF
--- a/root/thruk/javascript/thruk-1.86-4.js
+++ b/root/thruk/javascript/thruk-1.86-4.js
@@ -1762,7 +1762,7 @@ function updateExcelPermanentLink() {
 
 /* print the action menu icons and action icons */
 var menu_nr = 0;
-function print_action_menu(src, backend, host, service, orientation) {
+function print_action_menu(src, backend, host, service, orientation, label) {
     try {
         if(orientation == undefined) { orientation = 'b-r'; }
         src = is_array(src) ? src : [src];
@@ -1771,6 +1771,7 @@ function print_action_menu(src, backend, host, service, orientation) {
             icon.src       = replace_macros(e.icon);
             icon.className = 'action_icon '+(e.menu ? 'clickable' : '' );
             icon.title     = e.title ? e.title : '';
+            var text       = document.createTextNode(icon.title);
             if(e.menu) {
                 icon.nr = menu_nr;
                 icon.onclick = function() {
@@ -1793,6 +1794,9 @@ function print_action_menu(src, backend, host, service, orientation) {
             // obtain reference to current script tag so we could insert the icons here
             var scriptTag = document.scripts[document.scripts.length - 1];
             scriptTag.parentNode.appendChild(item);
+            if(label) {
+                scriptTag.parentNode.appendChild(text);
+            }
         });
     }
     catch(e) {

--- a/templates/extinfo_type_1.tt
+++ b/templates/extinfo_type_1.tt
@@ -113,7 +113,7 @@
           [% cust_vars = get_custom_vars(c, host); IF cust_vars.exists('THRUK_ACTION_MENU') %]
             <tr>
               <td align='left'>
-                [% tmp = get_action_menu(c, cust_vars.THRUK_ACTION_MENU); err = tmp.0; action_menu = tmp.1; IF err %]<img src="[% url_prefix %]themes/[% theme %]/images/error.png" title="[% escape_quotes(err) %]" alt="json error" width=16 height=16>[% ELSE %]<script type="text/javascript">print_action_menu([% action_menu %], '[% host.peer_key %]', '[% host.name %]', undefined, 'b-l');</script>[% END %]
+                [% tmp = get_action_menu(c, cust_vars.THRUK_ACTION_MENU); err = tmp.0; action_menu = tmp.1; IF err %]<img src="[% url_prefix %]themes/[% theme %]/images/error.png" title="[% escape_quotes(err) %]" alt="json error" width=16 height=16>[% ELSE %]<script type="text/javascript">print_action_menu([% action_menu %], '[% host.peer_key %]', '[% host.name %]', undefined, 'b-l', true);</script>[% END %]
                 <br clear="all">
               </td>
             </tr>

--- a/templates/extinfo_type_2.tt
+++ b/templates/extinfo_type_2.tt
@@ -110,7 +110,7 @@
           [% cust_vars = get_custom_vars(c, service); IF cust_vars.exists('THRUK_ACTION_MENU') %]
             <tr>
               <td align='left'>
-                [% tmp = get_action_menu(c, cust_vars.THRUK_ACTION_MENU); err = tmp.0; action_menu = tmp.1; IF err %]<img src="[% url_prefix %]themes/[% theme %]/images/error.png" title="[% escape_quotes(err) %]" alt="json error" width=16 height=16>[% ELSE %]<script type="text/javascript">print_action_menu([% action_menu %], '[% service.peer_key %]', '[% service.host_name %]', '[% service.description %]', 'b-l');</script>[% END %]
+                [% tmp = get_action_menu(c, cust_vars.THRUK_ACTION_MENU); err = tmp.0; action_menu = tmp.1; IF err %]<img src="[% url_prefix %]themes/[% theme %]/images/error.png" title="[% escape_quotes(err) %]" alt="json error" width=16 height=16>[% ELSE %]<script type="text/javascript">print_action_menu([% action_menu %], '[% service.peer_key %]', '[% service.host_name %]', '[% service.description %]', 'b-l', true);</script>[% END %]
                 <br clear="all">
               </td>
             </tr>


### PR DESCRIPTION
The action menu can get lost on the extinfo pages. This can obviously
depend on the icon used as well but having the menu title displayed
makes the menu a bit more visible. If someone doesn't like the menu
title displayed they can just not use one in their configuration.

Without the action menu label displayed (this is how it works now):

![nolabel](https://cloud.githubusercontent.com/assets/3237256/6585570/1535a64a-c749-11e4-889c-653f01a143db.PNG)

Label for a service action menu:

![servicelabel](https://cloud.githubusercontent.com/assets/3237256/6585571/1b6ad076-c749-11e4-9902-3c875965a671.PNG)

Label for a host action menu:

![hostlabel](https://cloud.githubusercontent.com/assets/3237256/6585581/285b99e6-c749-11e4-8532-dc910640ef63.PNG)

