### PR TITLE
Fix PNP4Nagios Selector CSS

### DIFF
--- a/templates/_pnp_graph.tt
+++ b/templates/_pnp_graph.tt
@@ -29,7 +29,7 @@
   <tr>
     <td style="position: relative;">
         <div class='commentTitle'>Performance Graph</div>
-        <div style="display: inline; position: absolute; right: 2px; top: 22px;">
+        <div class='pnpSelector'>
           <form action="#">
             <select onchange="pnp_source=this.value; set_png_img();" id="pnp_source_select" style="display: none;">
             </select>

--- a/themes/themes-available/Classic/stylesheets/thruk_global.css
+++ b/themes/themes-available/Classic/stylesheets/thruk_global.css
@@ -1191,3 +1191,10 @@ UL.action_menu LI.clickable A {
 UL.action_menu LI HR {
   margin: 2px 8px;
 }
+
+DIV.pnpSelector {
+  display: inline;
+  position: absolute;
+  right: 2px;
+  top: 22px;
+}

--- a/themes/themes-available/Exfoliation/stylesheets/Exfoliation.css
+++ b/themes/themes-available/Exfoliation/stylesheets/Exfoliation.css
@@ -50,3 +50,5 @@ td.filter { background-color: white; }
 table.cmd_pane { background: none; }
 table.cmd_pane tbody > tr > td { background: #f0f1ee; border: none; }
 table.cmd_pane th,table.cmd_pane a,table.cmd_pane a:hover { background: #f0f1ee; color: #333333; }
+
+div.pnpSelector { display: inline; position: absolute; right: 2px; top: -6px; }


### PR DESCRIPTION
Move the CSS from being an inline style to `thruk_global.css` so that themes can override it if necessary.

Fix the selector in the Exfoliation theme.

Before:
![image](https://cloud.githubusercontent.com/assets/3237256/7666905/88f7a38a-fbc4-11e4-8121-adb5b24066bc.png)

After:
![image](https://cloud.githubusercontent.com/assets/3237256/7666902/788210da-fbc4-11e4-8518-9f2005487a6e.png)
