### PR TITLE
incr_parse() panics which results into empty report files.

### DIFF
--- a/lib/Thruk/Utils/IO.pm
+++ b/lib/Thruk/Utils/IO.pm
@@ -187,22 +187,19 @@ retrieve json data
 =cut
 
 sub json_lock_retrieve {
+    #smetj;
     my($file) = @_;
 
     my $json = JSON::XS->new->utf8;
-    my $data;
-
-    open(my $fh, '<', $file) or die('cannot read file '.$file.': '.$!);
+    $json->relaxed();
+    local $/=undef;
+    open FILE, $file or die('cannot read file '.$file.': '.$!);
     alarm(30);
     local $SIG{'ALRM'} = sub { die("timeout while trying to lock_sh: ".$file); };
-    flock($fh, LOCK_SH) or die 'Cannot lock '.$file.': '.$!;
-    while(my $line = <$fh>) {
-        $json->incr_parse($line);
-    }
-    $data = $json->incr_parse;
-    flock($fh, LOCK_UN) or die 'Cannot unlock '.$file.': '.$!;
+    flock(FILE, LOCK_SH) or die 'Cannot lock '.$file.': '.$!;
+    my $data = $json->decode(<FILE>);
+    CORE::close(FILE);
     alarm(0);
-    CORE::close($fh);
     return $data;
 }
 


### PR DESCRIPTION
I have observed $data = $json->incr_parse; to panic on rhel 6.2 with perfectly valid JSON files.

The logged message in such case was:
Failed to read json /var/lib/thruk/reports/76.rpt; panic: sv_chop ptr=4175a93 (was 4175a93), start=4172ec0, end=4173090 at /usr/share/thruk/lib/Thruk/Utils/IO.pm line 217, <$fh> line 21.

When this happens the report file in question (/var/lib/thruk/reports/76.rpt) got overwritten with a default version.

Using this patch prevented the panic from happening.