### PR TITLE
graphite: Strip spaces to make graph names compatible with graphios

### DIFF
--- a/lib/Thruk/Utils.pm
+++ b/lib/Thruk/Utils.pm
@@ -1405,11 +1405,13 @@ sub get_action_url {
         for my $regex (@{list($graph_word)}) {
             if ($action_url =~ m|$regex|mx){
                 my $new_host = $host;
+                $new_host =~ s/\s//gmx;
                 $new_host =~ s/[^\w\-]/_/gmx;
                 $new_action_url =~ s/\Q$host\E/$new_host/gmx;
 
                 if ($svc) {
                     my $new_svc = $svc;
+                    $new_svc =~ s/\s//gmx;
                     $new_svc =~ s/[^\w\-]/_/gmx;
                     $new_action_url =~ s/\Q$svc\E/$new_svc/gmx;
                 }


### PR DESCRIPTION
Graphios strips spaces before replacing non-alphanumerics with _. This
makes thruk's name mangling do the same thing.