### PR TITLE
Added support for contact_groups in hosts and services.

### DIFF
--- a/lib/Thruk/Controller/config.pm
+++ b/lib/Thruk/Controller/config.pm
@@ -68,7 +68,7 @@ sub index {
         if(defined $c->req->parameters->{'jump2'}) {
             $filter = [ { 'name' => $c->req->parameters->{'jump2'} } ];
         }
-        $c->{'db'}->get_hosts(sort => 'name', remove_duplicates => 1, pager => 1, extra_columns => ['contacts'], filter => $filter );
+        $c->{'db'}->get_hosts(sort => 'name', remove_duplicates => 1, pager => 1, extra_columns => ['contacts', 'contact_groups'], filter => $filter );
         $c->stash->{template} = 'config_hosts.tt';
     }
 
@@ -78,7 +78,7 @@ sub index {
         if( defined $c->req->parameters->{'jump2'} and defined $c->req->parameters->{'jump3'} ) {
             $filter = [ { 'host_name' => $c->req->parameters->{'jump2'}, 'description' => $c->req->parameters->{'jump3'} } ];
         }
-        $c->{'db'}->get_services(sort => [ 'host_name', 'description' ], remove_duplicates => 1, pager => 1, extra_columns => ['contacts'], filter => $filter);
+        $c->{'db'}->get_services(sort => [ 'host_name', 'description' ], remove_duplicates => 1, pager => 1, extra_columns => ['contacts', 'contact_groups'], filter => $filter);
         $c->stash->{template} = 'config_services.tt';
     }
 

--- a/templates/config_hosts.tt
+++ b/templates/config_hosts.tt
@@ -12,6 +12,7 @@
     <th class='data'>Address</th>
     <th class='data'>Parent Hosts</th>
     <th class='data'>Contacts</th>
+    <th class='data'>Contact Groups</th>
     <th class='data'>Max. Check Attempts</th>
     <th class='data'>Check Interval</th>
     <th class='data'>Retry Interval</th>
@@ -88,6 +89,7 @@
     <td class='[% class %]'>[% d.address %]</td>
     <td class='[% class %]'>[% FOREACH parent = d.parents %][% IF !loop.first() %], [% END %]<a href="config.cgi?type=hosts&amp;jump=[% parent | uri %]#[% parent | uri %]">[% parent %]</a>[% END %]</td>
     <td class='[% class %]'>[% FOREACH contact = d.contacts.sort %][% IF !loop.first() %] , [% END %]<a href="config.cgi?type=contacts&amp;jump=[% contact | uri %]#[% contact | uri %]">[% contact %]</a>[% END %]</td>
+    <td class='[% class %]'>[% FOREACH contact_group = d.contact_groups.sort %][% IF !loop.first() %] , [% END %]<a href="config.cgi?type=contactgroups&amp;jump=[% contact_group | uri %]#[% contact_group | uri %]">[% contact_group %]</a>[% END %]</td>
     <td class='[% class %]'>[% d.max_check_attempts %]</td>
     <td class='[% class %]'>[% duration(d.check_interval * pi_detail.$pd.interval_length, 0 ) %]</td>
     <td class='[% class %]'>[% duration(d.retry_interval * pi_detail.$pd.interval_length, 0 ) %]</td>

--- a/templates/config_services.tt
+++ b/templates/config_services.tt
@@ -16,6 +16,7 @@
     <th class='data'>Host</th>
     <th class='data'>Description</th>
     <th class='data'>Contacts</th>
+    <th class='data'>Contact Groups</th>
     <th class='data'>Max. Check Attempts</th>
     <th class='data'>Normal Check Interval</th>
     <th class='data'>Retry Check Interal</th>
@@ -87,6 +88,7 @@
     <td class='[% class %]'><a href="config.cgi?type=hosts&amp;jump=[% d.host_name | uri %]#[% d.host_name | uri %]">[% d.host_name %]</a></td>
     <td class='[% class %]'>[% d.description %]</td>
     <td class='[% class %]'>[% FOREACH contact = d.contacts.sort %][% IF !loop.first() %] , [% END %]<a href="config.cgi?type=contacts&amp;jump=[% contact | uri %]#[% contact | uri %]">[% contact %]</a>[% END %]</td>
+    <td class='[% class %]'>[% FOREACH contact_group = d.contact_groups.sort %][% IF !loop.first() %] , [% END %]<a href="config.cgi?type=contactgroups&amp;jump=[% contact_group | uri %]#[% contact_group | uri %]">[% contact_group %]</a>[% END %]</td>
     <td class='[% class %]'>[% d.max_check_attempts %]</td>
     <td class='[% class %]'>[% duration(d.check_interval * pi_detail.$pd.interval_length, 0 ) %]</td>
     <td class='[% class %]'>[% duration(d.retry_interval * pi_detail.$pd.interval_length, 0 ) %]</td>


### PR DESCRIPTION
Hosts and services can show the contact_groups.
Requires at least livestatus from 16 Aug 2011 http://git.mathias-kettner.de/git/?p=check_mk.git;a=commit;h=9b0a27252143050f529f12bcf3cd522a4cc49dbf