### PR TITLE
Adding nowrap to the bookmarks menu

### DIFF
--- a/themes/themes-available/Vautour/stylesheets/interface/menu.css
+++ b/themes/themes-available/Vautour/stylesheets/interface/menu.css
@@ -79,6 +79,7 @@ ul {
 
 #menu ul li.menuli_style1 {
   background-color: #ededed;
+  white-space:nowrap;
 }
 
 #menu ul li.menuli_style2 {


### PR DESCRIPTION
The Vatour theme wraps poorly with long names in the Bookmarks menu.