### PR TITLE
Revert "graphite: Strip spaces to make graph names compatible with graphios"

### DIFF
--- a/lib/Thruk/Utils.pm
+++ b/lib/Thruk/Utils.pm
@@ -1517,13 +1517,11 @@ sub get_action_url {
         for my $regex (@{list($graph_word)}) {
             if ($action_url =~ m|$regex|mx){
                 my $new_host = $host;
-                $new_host =~ s/\s//gmx;
                 $new_host =~ s/[^\w\-]/_/gmx;
                 $new_action_url =~ s/\Q$host\E/$new_host/gmx;
 
                 if ($svc) {
                     my $new_svc = $svc;
-                    $new_svc =~ s/\s//gmx;
                     $new_svc =~ s/[^\w\-]/_/gmx;
                     $new_action_url =~ s/\Q$svc\E/$new_svc/gmx;
                 }


### PR DESCRIPTION
Reverts sni/Thruk#531
Breaks Graphite integration (Graphite replace spaces with underscores).