### PR TITLE
restrict the columns that are requested during host and service query

### DIFF
--- a/lib/Thruk/Controller/status.pm
+++ b/lib/Thruk/Controller/status.pm
@@ -870,7 +870,7 @@ sub _process_summary_page {
 
     if( $c->stash->{substyle} eq 'host' ) {
         # we need the hosts data
-        my $host_data = $c->{'db'}->get_hosts( filter => [ Thruk::Utils::Auth::get_auth_filter( $c, 'hosts' ), $hostfilter ] );
+        my $host_data = $c->{'db'}->get_hosts( filter => [ Thruk::Utils::Auth::get_auth_filter( $c, 'hosts' ), $hostfilter ], columns => [ qw /action_url_expanded notes_url_expanded icon_image_alt icon_image_expanded address has_been_checked name state display_name custom_variable_names custom_variable_values/ ] );
         for my $host ( @{$host_data} ) {
             for my $group ( @{ $host->{'groups'} } ) {
                 next if !defined $all_groups->{$group};
@@ -879,7 +879,7 @@ sub _process_summary_page {
         }
     }
     # create a hash of all services
-    my $services_data = $c->{'db'}->get_services( filter => [ Thruk::Utils::Auth::get_auth_filter( $c, 'services' ), $servicefilter ] );
+    my $services_data = $c->{'db'}->get_services( filter => [ Thruk::Utils::Auth::get_auth_filter( $c, 'services' ), $servicefilter ], columns => [ qw /description state host_name acknowledged has_been_checked host_state checks_enabled check_type scheduled_downtime_depth host_groups groups/] );
 
     my $groupsname = "host_groups";
     if( $c->stash->{substyle} eq 'service' ) {


### PR DESCRIPTION
Hi,
this PR restricts the columns that are requested in a Hostgroup Summary page, thus improving performance. My testcase and measurements:

  -- my private notebook 8gb ram, core i3 with ht
  -- Shinken/Livestatus with 40 hostgroups, times 10 hosts, times 2 services
  -- thruk_server.pl from git, thruk->livestatus via tcp, nginx frontend.
  -- use jmeter to query /thruk/cgi-bin/status.cgi?hostgroup=all&style=summary
  -- run each jmeter case for 20 minutes

per request statistics:

before:
  -- single user: avg 10.6s / min 9.0s / max 20.0s / 0% error
  -- ten concurrent users: 59.2s avg / min 9.6s / max 60.0s / 97.0% error *

after:
  -- single threaded acces ~ 2.7s avg / 2.3s min / 6.0s max / 0% error
  -- ten concurrent users: ~ 26.6s avg / 2.6s min / 30.2s max / 0% error

My intention is, for this pr to have no feature impacts.

* timeout limit is 60s, i don't see a point to raise it, the result in inacceptable
