### PR TITLE
authorization problem with external auth

### DIFF
--- a/lib/Thruk/Authentication/User.pm
+++ b/lib/Thruk/Authentication/User.pm
@@ -46,10 +46,10 @@ sub new {
         $username = $c->stash->{'remote_user'};
     }
     # basic authentication
-    elsif(defined $env->{'REMOTE_USER'}) {
+    elsif(defined $env->{'REMOTE_USER'} and $env->{'REMOTE_USER'} ne '' ) {
         $username = $env->{'REMOTE_USER'};
     }
-    elsif(defined $ENV{'REMOTE_USER'}) {
+    elsif(defined $ENV{'REMOTE_USER'}and $ENV{'REMOTE_USER'} ne '' ) {
         $username = $ENV{'REMOTE_USER'};
     }
 


### PR DESCRIPTION
I had an authorization problem with external_auth and shibboleth. The problem was the shibboleth mod, because if you use lazy session, the shib mod define the REMOTE_USER variable to "". In earlier shib versions the shib mod leave the REMOTE_USER variable undefined.

shibboleth: 2.5.3
apache: 2.4.10