### PR TITLE
Fixes Undefined subroutine &Thruk::naglint::pod2usage

### DIFF
--- a/script/naglint
+++ b/script/naglint
@@ -179,6 +179,7 @@ package Thruk::naglint;
 use strict;
 use warnings;
 use Getopt::Long;
+use Pod::Usage;
 use Thruk::Config;
 use Thruk::Utils::Scripts;
 use Monitoring::Config;


### PR DESCRIPTION
On Debian calling --help gives me this error message:

/usr/bin/naglint --help
Undefined subroutine &Thruk::naglint::pod2usage called at /usr/bin/naglint line 220.
