### PR TITLE
 Make it possible to run a user-defined login hook. 

### DIFF
--- a/docs/documentation/configuration.asciidoc
+++ b/docs/documentation/configuration.asciidoc
@@ -421,6 +421,17 @@ ex.:
 
 
 
+=== user_auth_login_hook
+
+Hook which will be called in the process when an user is about to be authorized.
+The hook enables integration with SSO services (e.g Shibboleth) since it is
+exposed to the web servers environment. If the hook exit anything but 0 the
+user will be denied.
+
+ex.:
+
+  user_auth_login_hook = /bin/false
+
 
 
 == Path Settings

--- a/lib/Thruk/Authentication/User.pm
+++ b/lib/Thruk/Authentication/User.pm
@@ -75,8 +75,8 @@ sub new {
         system($user_auth_login_hook);
         if ($? != 0) {
             return;
-        };
-    };
+        }
+    }
 
     # change case?
     $username = lc($username) if $c->config->{'make_auth_user_lowercase'};

--- a/lib/Thruk/Authentication/User.pm
+++ b/lib/Thruk/Authentication/User.pm
@@ -66,6 +66,18 @@ sub new {
         return;
     }
 
+    my $user_auth_login_hook = $c->config->{'user_auth_login_hook'};
+    if ($user_auth_login_hook) {
+        # Expose the user_auth_login_hook to the web server %ENV that provides useful information.
+        local %ENV = %{$env};
+        # Was "IGNORE". We can't just fire and forget since we rely on the result from the hook.
+        local $SIG{CHLD} = 'DEFAULT';
+        system($user_auth_login_hook);
+        if ($? != 0) {
+            return;
+        };
+    };
+
     # change case?
     $username = lc($username) if $c->config->{'make_auth_user_lowercase'};
     $username = uc($username) if $c->config->{'make_auth_user_uppercase'};

--- a/thruk.conf
+++ b/thruk.conf
@@ -94,6 +94,11 @@ disable_user_password_change = 0
 # just affects the user password reset.
 user_password_min_length = 5
 
+# Check externally if the authenticated user is allowed access.
+# The hook will be exposed to the actual web servers environment for
+# easy integration with SSO services.
+#user_auth_login_hook = /bin/false
+
 # maximum memory usage (in MB) after which a
 # thruk process will exit after the request
 # (fcgid only)


### PR DESCRIPTION
Hook which will be called in the process when an user is about to be authorized.
The hook enables integration with SSO services (e.g Shibboleth) since it is
exposed to the web servers environment. If the hook exit any thing but 0 the
user will be denied.