### PR TITLE
obfuscate both command line & expanded command line

### DIFF
--- a/lib/Thruk/Utils/CLI.pm
+++ b/lib/Thruk/Utils/CLI.pm
@@ -855,7 +855,7 @@ sub _cmd_command {
     my $msg;
     $msg .= 'Note:            '.$command->{'note'}."\n" if $command->{'note'};
     $msg .= 'Check Command:   '.$command->{'line'}."\n";
-    $msg .= 'Expaned Command: '.$command->{'line_expanded'}."\n";
+    $msg .= 'Expanded Command: '.$command->{'line_expanded'}."\n";
 
     $c->stats->profile(end => "_cmd_command()");
     return $msg;


### PR DESCRIPTION
When using the _OBFUSCATE_ME macro, only in the expanded command line the secrets were replaced by ***. 
Community strings etc. were still visible in the upper line with the unexpanded command.