### PR TITLE
Added minimal=2 which is minimal=1 + backends view

### DIFF
--- a/templates/_header.tt
+++ b/templates/_header.tt
@@ -46,6 +46,22 @@
      Copyright (c) 2009 Nagios Core Development Team and Community Contributors.
      Copyright (c) 1999-2009 Ethan Galstad.
 -->
+
+[% IF minimal == 2 %]
+<ul class="headerBackends">
+[% FOREACH pd IN backends %]
+[% UNLESS backend_detail.$pd.disabled %]
+  [% SET backend_status_class = 'UNKNOWN' %]
+  [% SET backend_status_class = 'UP' IF backend_detail.$pd.running %]
+  [% SET backend_status_class = 'DOWN' IF failed_backends.defined(pd) %]
+  <li class="backendStatus[% backend_status_class %]">
+    <span>[% backend_detail.$pd.name %]</span>
+  </li>
+[% END %]
+[% END %]
+</ul>
+[% END %]
+
 [% UNLESS minimal %]
 <table border="0" cellpadding=0 cellspacing=0 class="top_nav">
   <tr>

--- a/themes/themes-available/Classic/stylesheets/status.css
+++ b/themes/themes-available/Classic/stylesheets/status.css
@@ -101,3 +101,9 @@ TD.hostTotals { font-family: arial,serif;  font-size: 8pt;  text-align: center; 
 .serviceImportantProblem { text-align: left;  font-family: arial;  font-size: 8pt;  background-color: #ff0000;  color: black; text-decoration: blink; }
 .serviceUnimportantProblem { text-align: left;  font-family: arial;  font-size: 8pt;  background-color: #ffcccc;  color: black; }
 
+UL.headerBackends { display: inline; list-style-type: none; margin: 0; padding: 0; }
+UL.headerBackends LI { float: left; margin: 0 2px; }
+UL.headerBackends LI SPAN { display: block; padding: 2px 8px; white-space: nowrap;  font-family: arial,serif;  font-size: 8pt;  color: #000; }
+.backendStatusUNKNOWN { background: #FFDA9F; }
+.backendStatusUP { background: #33FF00; }
+.backendStatusDOWN { background: #F83838; }

--- a/themes/themes-available/Exfoliation/stylesheets/status.css
+++ b/themes/themes-available/Exfoliation/stylesheets/status.css
@@ -77,3 +77,10 @@ td.hostTotals          { font-size: 8pt; text-align: center; background-color: #
 .miniStatusUP          { font-size: 8pt; text-align: center; background-color: #88d066; border: 1px solid #777777; padding: 0 5px 0 5px; }
 .miniStatusDOWN        { font-size: 8pt; text-align: center; background-color: #f88888; border: 1px solid #777777; padding: 0 5px 0 5px; }
 .miniStatusUNREACHABLE { font-size: 8pt; text-align: center; background-color: #ffbb55; border: 1px solid #777777; padding: 0 5px 0 5px; }
+
+UL.headerBackends { display: inline; list-style-type: none; margin: 0; padding: 0; }
+UL.headerBackends LI { float: left; margin: 0 0 0 2px; }
+UL.headerBackends LI SPAN { display: block; padding: 2px 8px; white-space: nowrap; }
+.backendStatusUNKNOWN { font-size: 8pt; background: #ffbb55; border: 1px solid #777777; }
+.backendStatusUP      { font-size: 8pt; background: #88d066; border: 1px solid #777777; }
+.backendStatusDOWN    { font-size: 8pt; background: #f88888; border: 1px solid #777777; }

--- a/themes/themes-available/Nuvola/stylesheets/status.css
+++ b/themes/themes-available/Nuvola/stylesheets/status.css
@@ -152,3 +152,10 @@ white-space: nowrap;
 TABLE#statusTable tbody > tr > TD {
     padding-left: 2px;
 }
+
+UL.headerBackends { display: inline; list-style-type: none; margin: 0; padding: 0; }
+UL.headerBackends LI { float: left; margin: 0 0 0 2px; }
+UL.headerBackends LI SPAN { display: block; padding: 2px 8px; white-space: nowrap; }
+.backendStatusUNKNOWN { font-size: 8pt; background: #f0f1f5; }
+.backendStatusUP      { font-size: 8pt; background: #C0FFC0; }
+.backendStatusDOWN    { font-size: 8pt; background: #FFC0C0; }

--- a/themes/themes-available/Thruk/stylesheets/Thruk.css
+++ b/themes/themes-available/Thruk/stylesheets/Thruk.css
@@ -744,6 +744,36 @@ TD.statusEven {
   height:22px;
 }
 
+UL.headerBackends {
+  display:inline;
+  list-style-type:none;
+  margin:0;
+  padding:0;
+}
+
+UL.headerBackends LI {
+  float:left;
+  margin:0 0 0 2px;
+}
+
+UL.headerBackends LI SPAN {
+  display:block;
+  padding:2px 8px;
+  white-space:nowrap;
+}
+
+.backendStatusUNKNOWN {
+  background:#ff9e00;
+}
+
+.backendStatusUP {
+  background:#0f3;
+}
+
+.backendStatusDOWN {
+  background:#ff5b33;
+}
+
 TH.hostTotals {
   width:25%;
 }

--- a/themes/themes-available/Thruk2/stylesheets/Thruk2.css
+++ b/themes/themes-available/Thruk2/stylesheets/Thruk2.css
@@ -791,6 +791,36 @@ TD.statusEven {
   padding:1px;
 }
 
+UL.headerBackends {
+  display:inline;
+  list-style-type:none;
+  margin:0;
+  padding:0;
+}
+
+UL.headerBackends LI {
+  float:left;
+  margin:0 0 0 2px;
+}
+
+UL.headerBackends LI SPAN {
+  display:block;
+  padding:2px 8px;
+  white-space:nowrap;
+}
+
+.backendStatusUNKNOWN {
+  background:#33cc66;
+}
+
+.backendStatusUP {
+  background:#33cc66;
+}
+
+.backendStatusDOWN {
+  background:#f0666c;
+}
+
 TD.statusOdd.tableRowSelected, TD.statusEven.tableRowSelected, TD.tableRowSelected, TH.tableRowSelected {
   background-color:inherit;
 }

--- a/themes/themes-available/Vautour/stylesheets/status.css
+++ b/themes/themes-available/Vautour/stylesheets/status.css
@@ -119,3 +119,10 @@ a.hostTotals:hover { color: #000; }
 TABLE#statusTable tbody > tr > TD {
     padding-left: 2px;
 }
+
+UL.headerBackends { display: inline; list-style-type: none; margin: 0; padding: 0; }
+UL.headerBackends LI { float: left; margin: 0 2px; }
+UL.headerBackends LI SPAN { display: block; padding: 2px 8px; white-space: nowrap; }
+.backendStatusUNKNOWN { color: #fff; background: #bf44b2; }
+.backendStatusUP { color: #fff; background: #00cc33; }
+.backendStatusDOWN { color: #fff; background: #ff3300; }

--- a/themes/themes-available/Wakizashi/stylesheets/status.css
+++ b/themes/themes-available/Wakizashi/stylesheets/status.css
@@ -232,3 +232,9 @@ TD.hostTotals {} /* font-family: arial,serif;  font-size: 8pt;  text-align: cent
 .serviceImportantProblem { text-align: left;  font-family: arial;  font-size: 8pt;  background-color: #ff0000;  color: black; text-decoration: blink; }
 .serviceUnimportantProblem { text-align: left;  font-family: arial;  font-size: 8pt;  background-color: #ffcccc;  color: black; }
 
+UL.headerBackends { display: inline;  list-style-type: none;  margin: 0;  padding: 0; }
+UL.headerBackends LI { float: left;  margin: 0 2px; }
+UL.headerBackends LI SPAN { display: block;  padding: 2px 8px;  white-space: nowrap;  font-size: 12px;  font-weight: bold; }
+.backendStatusUNKNOWN { background: #FF9900; }
+.backendStatusUP { background: #00FF80/*ACFA58*/ }
+.backendStatusDOWN { background: #FA5858/*FAA*/; }


### PR DESCRIPTION
This Pull Request is about talk on IRC about year or more ago which was approved that time, but I couldn't find time to do cleanup code until today ;)

This Pull Request adds minimal view with backends status so it's possible to know when backend fails. Previously user who looked at minimal view has no knowledge about that, hence he never knew if what we saw was correct or not (because user has no knowledge if no CRITICALs is because everything is OK, or because some backend failed so he could not see any CRITICALs)

This adds small code into `_header.tt` template to show HTML elements when URL has `minimal=2`, and CSS classes to every currently known themes (including `Thruk2` which is not included currently in CentOS package, not ready yet? — but not tested).

All colors and fonts are copied from service status CSS.

Example screenshots included.

"Exfoliation" theme:
![screenshot from 2017-02-08 16-37-34](https://cloud.githubusercontent.com/assets/783794/22744609/1db2794e-ee1e-11e6-8b79-9b4060178f01.png)

"Neat" theme:
![screenshot from 2017-02-08 16-37-39](https://cloud.githubusercontent.com/assets/783794/22744610/1db3f2f6-ee1e-11e6-8f25-c727c1af96fd.png)
