### PR TITLE
Fix for Livestatus state_type

### DIFF
--- a/lib/Thruk/Backend/Provider/Mysql.pm
+++ b/lib/Thruk/Backend/Provider/Mysql.pm
@@ -1705,7 +1705,7 @@ sub _insert_logs {
         my $state             = $l->{'state'};
         my $state_type        = $l->{'state_type'};
         if($state eq '')      { $state   = 'NULL'; }
-        if($state_type eq '') { undef $state_type; } # if set to NULL then $dbh->quote($state_type) returns 'NULL' instead of NULL.
+        if(($state_type eq '') || (($state_type ne 'HARD') && ($state_type ne 'SOFT'))) { undef $state_type; } # if set to NULL then $dbh->quote($state_type) returns 'NULL' instead of NULL. Only accept HARD or SOFT state
         my($host, $svc, $contact) = ('NULL', 'NULL', 'NULL');
         if($l->{'service_description'}) {
             $host = $host_lookup->{$l->{'host_name'}} || &_host_lookup($host_lookup, $l->{'host_name'}, $dbh, $prefix);


### PR DESCRIPTION
Livestatus returns state_type other then HARD / SOFT. Thruk only accepts HARD / SOFT.
In case livestatus returns a value other then HARD / SOFT it will be set to NULL in the database.
This still not perfect because you can have state="CURRENT SERVICE STATE" and state_type="HARD", which is not supported according to the documentation: https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/4/en/statetypes.html