### PR TITLE
Set focus on search field

### DIFF
--- a/templates/_table_search_field.tt
+++ b/templates/_table_search_field.tt
@@ -10,6 +10,7 @@
 jQuery(document).ready(function() {
     // preserve hash
     jQuery("TABLE#[% id %] A").on('click', preserve_hash);
+    jQuery("#table_search_input").focus();
 });
 [%+ END +%]
 -->


### PR DESCRIPTION
If you open thruk/#cgi-bin/config.cgi?type=contactgroups&entries=all&total_pages=1#|mygroup the filter does not get applied. You have to click in the search field first. This fix will set the focus automatically on the search field. This way the URL will work and you can start typing after the page is loaded.