### PR TITLE
lock status table before selecting from it during logcacheupdate

### DIFF
--- a/lib/Thruk/Backend/Provider/Mysql.pm
+++ b/lib/Thruk/Backend/Provider/Mysql.pm
@@ -1074,6 +1074,7 @@ sub _update_logcache {
         $mode = 'import';
     } else {
         eval {
+            $dbh->do('LOCK TABLES `'.$prefix.'_status` WRITE');
             my @pids = @{$dbh->selectcol_arrayref('SELECT value FROM `'.$prefix.'_status` WHERE status_id = 2 LIMIT 1')};
             if(scalar @pids > 0 and $pids[0]) {
                 if(kill(0, $pids[0])) {
@@ -1092,7 +1093,6 @@ sub _update_logcache {
     }
     return(-1) if $skip;
 
-    $dbh->do('LOCK TABLES `'.$prefix.'_status` WRITE');
     $dbh->do("INSERT INTO `".$prefix."_status` (status_id,name,value) VALUES(1,'last_update',UNIX_TIMESTAMP()) ON DUPLICATE KEY UPDATE value=UNIX_TIMESTAMP()");
     $dbh->do("INSERT INTO `".$prefix."_status` (status_id,name,value) VALUES(2,'update_pid',".$$.") ON DUPLICATE KEY UPDATE value=".$$);
     $dbh->commit or die $dbh->errstr;


### PR DESCRIPTION
Hi Sven,
some days ago I proposed a solution to a race condition I faced on our production systems, but I saw that you didn't apply it the correct way.
I decided to send you a pull request in order to avoid further misunderstandings.

## explanation:
The race condition occurs when more then one process select the same PID from the *_status table **before** one of those had the opportunity to write it's own PID in the table.
Locking the table before the select forces all processes to wait for the WRITE lock, and only one process at a time can select the pid, check if some other process is still running, and eventually write his own pid to the status table. This way the next process(es) will select the new PID and exit.