### PR TITLE
Add host alias to title.

### DIFF
--- a/templates/_status_detail_table.tt
+++ b/templates/_status_detail_table.tt
@@ -121,7 +121,7 @@
         <td class='[% hostclass %] host_name'>
           <table border="0" width='100%' cellpadding="0" cellspacing="0">
             <tr>
-              <td align="left" class='[% hostclass %]'><a href='extinfo.cgi?type=1&amp;host=[% s.host_name | uri %]' title='[% s.host_address %]'>[% s.host_display_name %]</a></td>
+              <td align="left" class='[% hostclass %]'><a href='extinfo.cgi?type=1&amp;host=[% s.host_name | uri %]' title='[% s.host_address %] - [% s.host_alias %]'>[% s.host_display_name %]</a></td>
               <td align="right">
                 [% PROCESS _status_host_attributes hostprefix="host_" host=s host_comment_count=host_comment_count with_status=0 %]
               </td>

--- a/templates/_status_hostdetail_table.tt
+++ b/templates/_status_hostdetail_table.tt
@@ -113,7 +113,7 @@
                 <td align="left">
                   <table border="0" cellpadding="0" cellspacing="0">
                     <tr>
-                      <td align="left" valign="middle" class='[% class %]'><a href='extinfo.cgi?type=1&amp;host=[% h.name | uri %]&amp;backend=[% h.peer_key %]' title='[% h.address %]'>[% h.display_name %]</a>&nbsp;</td>
+                      <td align="left" valign="middle" class='[% class %]'><a href='extinfo.cgi?type=1&amp;host=[% h.name | uri %]&amp;backend=[% h.peer_key %]' title='[% h.address %] - [% h.alias %]'>[% h.display_name %]</a>&nbsp;</td>
                     </tr>
                   </table>
                 </td>


### PR DESCRIPTION
When hovering cursor over host, Thruk displays host address attribute.

I propose to add the alias field to easily identify the host under the cursor.

PS: the host alias is under the icon image when present, but as no mandatory field, I think it is more ergonomic to display it when hovering the cursor over the host.

jfr