### PR TITLE
use always HAVING in query filters with composed 'message'

### DIFF
--- a/lib/Thruk/Backend/Provider/Mysql.pm
+++ b/lib/Thruk/Backend/Provider/Mysql.pm
@@ -674,6 +674,7 @@ sub _get_filter {
     # message filter have to go into a having clause
     $filter =~ s/WHERE\ \(\((.*)\)\ AND\ \)/WHERE ($1)/gmx;
     if($filter and $filter =~ m/message\ (NOT\ LIKE|NOT\ RLIKE|RLIKE|=|LIKE|!=)\ /mx) {
+        my $operator = $1;
         if($filter =~ s/^\ WHERE\ \((time\ >=\ \d+\ AND\ time\ <=\ \d+)//mx) {
             my $timef = $1;
             my $having = $filter;
@@ -687,7 +688,7 @@ sub _get_filter {
                 $filter = $filter.' HAVING ('.$having.')';
             }
         } else {
-            $filter =~ s/message\ RLIKE\ '/p1.output\ RLIKE\ '/gmx;
+            $filter =~ s/(.*) AND\ message\ RLIKE\ '([^']+)'(.*)/\1\3 HAVING (message $operator '\2')/gmx;
         }
     }
     $filter =~ s/\ AND\ \)/)/gmx;

--- a/lib/Thruk/Backend/Provider/Mysql.pm
+++ b/lib/Thruk/Backend/Provider/Mysql.pm
@@ -674,8 +674,7 @@ sub _get_filter {
     # message filter have to go into a having clause
     $filter =~ s/WHERE\ \(\((.*)\)\ AND\ \)/WHERE ($1)/gmx;
     if($filter and $filter =~ m/message\ (NOT\ LIKE|NOT\ RLIKE|RLIKE|=|LIKE|!=)\ /mx) {
-        my $operator = $1;
-        if($filter =~ s/^\ WHERE\ \((time\ >=\ \d+\ AND\ time\ <=\ \d+)//mx) {
+        if($filter =~ s/^\ WHERE\ \(((\(host_name\ =\ '.+'(\ AND\ service_description\ =\ '.+')?\)\ AND\ )?time\ >=\ \d+\ AND\ time\ <=\ \d+)//mx) {
             my $timef = $1;
             my $having = $filter;
             $filter = 'WHERE ('.$timef.')';
@@ -688,7 +687,7 @@ sub _get_filter {
                 $filter = $filter.' HAVING ('.$having.')';
             }
         } else {
-            $filter =~ s/(.*) AND\ message\ RLIKE\ '([^']+)'(.*)/\1\3 HAVING (message $operator '\2')/gmx;
+            $filter =~ s/message\ RLIKE\ '/p1.output\ RLIKE\ '/gmx;
         }
     }
     $filter =~ s/\ AND\ \)/)/gmx;


### PR DESCRIPTION
Hi Sven,

we noticed that searching in the showlog.cgi with a host and service parameter doesn't work as expected.
In fact, searching on the page without parameters (/thruk/cgi-bin/showlog.cgi), the select-sql is build in this way:

```
        SELECT
            l.time as time,
            l.class as class,
            l.type as type,
            l.state as state,
            l.state_type as state_type,
            IFNULL(h.host_name, "") as host_name,
            IFNULL(s.service_description, "") as service_description,
            p2.output as plugin_output,
            c.name as contact_name,
            CONCAT("[", CAST(l.time AS CHAR CHARACTER SET utf8 ) ,"] ",
                   IF(l.type IS NULL, "", IF(l.type != "", CONCAT(l.type, ": "), "")),
                   IF(l.contact_id IS NULL, "", CONCAT(c.name, ";")),
                   IF(h.host_name IS NULL, "", CONCAT(h.host_name, ";")),
                   IF(s.service_description IS NULL, "", CONCAT(s.service_description, ";")),
                   p1.output,
                   p2.output
                ) as message,
            "ac6e0" as peer_key
        FROM
            `ac6e0_log` l
            LEFT JOIN `ac6e0_host` h ON l.host_id = h.host_id
            LEFT JOIN `ac6e0_service` s ON l.service_id = s.service_id
            LEFT JOIN `ac6e0_plugin_output` p1 ON l.message = p1.output_id
            LEFT JOIN `ac6e0_plugin_output` p2 ON l.plugin_output = p2.output_id
            LEFT JOIN `ac6e0_contact` c ON l.contact_id = c.contact_id
        WHERE (time >= 1510095600 AND time <= 1510182000) HAVING (message RLIKE \'test_service\')
         ORDER BY l.time DESC
```

so using the 'HAVING' the query works.
The problem arises when searching with a host and a service specified in the parameters (/thruk/cgi-bin/showlog.cgi?entries=100&host=HostA&service=ServiceA&pattern=test_service&exclude_pattern=&start=2017-11-08+00%3A00&end=2017-11-09+00%3A00&archive=):

```
        SELECT
            l.time as time,
            l.class as class,
            l.type as type,
            l.state as state,
            l.state_type as state_type,
            IFNULL(h.host_name, "") as host_name,
            IFNULL(s.service_description, "") as service_description,
            p2.output as plugin_output,
            c.name as contact_name,
            CONCAT("[", CAST(l.time AS CHAR CHARACTER SET utf8 ) ,"] ",
                   IF(l.type IS NULL, "", IF(l.type != "", CONCAT(l.type, ": "), "")),
                   IF(l.contact_id IS NULL, "", CONCAT(c.name, ";")),
                   IF(h.host_name IS NULL, "", CONCAT(h.host_name, ";")),
                   IF(s.service_description IS NULL, "", CONCAT(s.service_description, ";")),
                   p1.output,
                   p2.output
                ) as message,
            "ac6e0" as peer_key
        FROM
            `ac6e0_log` l
            LEFT JOIN `ac6e0_host` h ON l.host_id = h.host_id
            LEFT JOIN `ac6e0_service` s ON l.service_id = s.service_id
            LEFT JOIN `ac6e0_plugin_output` p1 ON l.message = p1.output_id
            LEFT JOIN `ac6e0_plugin_output` p2 ON l.plugin_output = p2.output_id
            LEFT JOIN `ac6e0_contact` c ON l.contact_id = c.contact_id
         WHERE ((host_name = \'HostA\' AND service_description = \'ServiceA\') AND time >= 1510095600 AND time <= 1510182000 AND p1.output RLIKE \'test_service\')
         ORDER BY l.time DESC
```

the search goes automatically to p1.output instead staying to 'message' as expected, and a search on the output of the log message doesn't work anymore.

The proposed fix uses always a HAVING clause when searching on message without changing the query to p1.output.