### PR TITLE
Check if host_name exists before create service without host_name in _insert_logs()

### DIFF
--- a/lib/Thruk/Backend/Provider/Mysql.pm
+++ b/lib/Thruk/Backend/Provider/Mysql.pm
@@ -1958,7 +1958,7 @@ sub _insert_logs {
         if(($state_type eq '') || (($state_type ne 'HARD') && ($state_type ne 'SOFT'))) { undef $state_type; } # if set to NULL then $dbh->quote($state_type) returns 'NULL' instead of NULL. Only accept HARD or SOFT state
 
         my($host, $svc, $contact) = ('NULL', 'NULL', 'NULL');
-        if($l->{'service_description'}) {
+        if($l->{'host_name'} && $l->{'service_description'}) {
             $host = $host_lookup->{$l->{'host_name'}} || &_host_lookup($host_lookup, $l->{'host_name'}, $dbh, $prefix, $auto_increments, $foreign_key_stash);
             $svc  = $service_lookup->{$l->{'host_name'}}->{$l->{'service_description'}} || &_service_lookup($service_lookup, $host_lookup, $l->{'host_name'}, $l->{'service_description'}, $dbh, $prefix, $host, $auto_increments, $foreign_key_stash);
         }


### PR DESCRIPTION
Hi Sni,

When i import the nagios logs in the nagios_log_cache using `thruk -a logcacheimport` or `thruk -a logcacheupdate` i get a fatal error because I have a malformed log in the nagios logs.

The malformed log is this:
```
[1504994769] SERVICE ALERT: ;PING;WARNING;SOFT;2;WARNING - x.x.x.x: rta x.xms, lost xx%
```
and as you can see the host_name is missing.

The error I get is this:
```
# thruk -a logcacheimport --local -y
running import for site Local Nagios
latest entry in logfile:  Fri Nov 10 11:25:43 2017
importing Thu Oct  5 00:00:00 2017 till Fri Nov 10 11:25:43 2017
Thu Oct  5 00:00:00 2017. 58 entries added
Fri Oct  6 00:00:00 2017. 54 entries added
Sat Oct  7 00:00:00 2017. 54 entries added
Sun Oct  8 00:00:00 2017. 63 entries added
Mon Oct  9 00:00:00 2017. 51 entries added
Tue Oct 10 00:00:00 2017. 49 entries added
Wed Oct 11 00:00:00 2017. 53 entries added
Thu Oct 12 00:00:00 2017. 52 entries added
Fri Oct 13 00:00:00 2017. 57 entries added
Sat Oct 14 00:00:00 2017. 58 entries added
Sun Oct 15 00:00:00 2017. 58 entries added
Mon Oct 16 00:00:00 2017. 57 entries added
Tue Oct 17 00:00:00 2017. 59 entries added
Wed Oct 18 00:00:00 2017. 53 entries added
Thu Oct 19 00:00:00 2017. 52 entries added
Fri Oct 20 00:00:00 2017. 55 entries added
Sat Oct 21 00:00:00 2017.. 118 entries added
Sun Oct 22 00:00:00 2017.. 110 entries added
Mon Oct 23 00:00:00 2017. 60 entries added
Tue Oct 24 00:00:00 2017. 57 entries added
Wed Oct 25 00:00:00 2017. 58 entries added
Thu Oct 26 00:00:00 2017. 56 entries added
Fri Oct 27 00:00:00 2017. 57 entries added
Sat Oct 28 00:00:00 2017. 55 entries added
Sun Oct 29 00:00:00 2017. 53 entries added
Sun Oct 29 23:00:00 2017. 60 entries added
Mon Oct 30 23:00:00 2017. 57 entries added
Tue Oct 31 23:00:00 2017. 58 entries added
Wed Nov  1 23:00:00 2017. 56 entries added
Thu Nov  2 23:00:00 2017. 54 entries added
Fri Nov  3 23:00:00 2017. 51 entries added
Sat Nov  4 23:00:00 2017. 54 entries added
Sun Nov  5 23:00:00 2017. 52 entries added
Mon Nov  6 23:00:00 2017. 64 entries added
Tue Nov  7 23:00:00 2017. 59 entries added
Wed Nov  8 23:00:00 2017. 51 entries added
Thu Nov  9 23:00:00 2017DBD::mysql::db do failed: Column 'host_id' cannot be null at /var/lib/neteye/thruk/lib/Thruk/Backend/Provider/Mysql.pm line 1420.
ERROR: DBD::mysql::db do failed: Column 'host_id' cannot be null at /var/lib/neteye/thruk/lib/Thruk/Backend/Provider/Mysql.pm line 1420.


ERROR - imported 0 log items from 1 site with 1 errors in 0.30s (0/s)
```

This append because the service_lookup() function is trying to  create a service without a host.

I fixed this problem by check if the host_name and the service_description are defined and not empty before doing the host_lookup and service_lookup.

Bye