### PR TITLE
Added host_notes to query

### DIFF
--- a/lib/Thruk/Backend/Manager.pm
+++ b/lib/Thruk/Backend/Manager.pm
@@ -1147,6 +1147,7 @@ sub _set_host_macros {
     $macros->{'$HOSTPERFDATA$'}       = (defined $host->{'host_perf_data'})          ? $host->{'host_perf_data'}          : $host->{'perf_data'};
     $macros->{'$HOSTATTEMPT$'}        = (defined $host->{'host_current_attempt'})    ? $host->{'host_current_attempt'}    : $host->{'current_attempt'};
     $macros->{'$HOSTCHECKCOMMAND$'}   = (defined $host->{'host_check_command'})      ? $host->{'host_check_command'}      : $host->{'check_command'};
+    $macros->{'$HOSTNOTES$'}          = (defined $host->{'host_notes'})              ? $host->{'host_notes'}              : $host->{'notes_url'};
     $macros->{'$HOSTNOTESURL$'}       = (defined $host->{'host_notes_url_expanded'}) ? $host->{'host_notes_url_expanded'} : $host->{'notes_url_expanded'};
     $macros->{'$HOSTDURATION$'}       = (defined $host->{'host_last_state_change'})  ? $host->{'host_last_state_change'}  : $host->{'last_state_change'};
     $macros->{'$HOSTDURATION$'}       = (defined $macros->{'$HOSTDURATION$'})        ? time() - $macros->{'$HOSTDURATION$'} : 0;

--- a/lib/Thruk/Backend/Manager.pm
+++ b/lib/Thruk/Backend/Manager.pm
@@ -1147,7 +1147,7 @@ sub _set_host_macros {
     $macros->{'$HOSTPERFDATA$'}       = (defined $host->{'host_perf_data'})          ? $host->{'host_perf_data'}          : $host->{'perf_data'};
     $macros->{'$HOSTATTEMPT$'}        = (defined $host->{'host_current_attempt'})    ? $host->{'host_current_attempt'}    : $host->{'current_attempt'};
     $macros->{'$HOSTCHECKCOMMAND$'}   = (defined $host->{'host_check_command'})      ? $host->{'host_check_command'}      : $host->{'check_command'};
-    $macros->{'$HOSTNOTES$'}          = (defined $host->{'host_notes'})              ? $host->{'host_notes'}              : $host->{'notes_url'};
+    $macros->{'$HOSTNOTES$'}          = (defined $host->{'host_notes'})              ? $host->{'host_notes'}              : $host->{'host_notes'};
     $macros->{'$HOSTNOTESURL$'}       = (defined $host->{'host_notes_url_expanded'}) ? $host->{'host_notes_url_expanded'} : $host->{'notes_url_expanded'};
     $macros->{'$HOSTDURATION$'}       = (defined $host->{'host_last_state_change'})  ? $host->{'host_last_state_change'}  : $host->{'last_state_change'};
     $macros->{'$HOSTDURATION$'}       = (defined $macros->{'$HOSTDURATION$'})        ? time() - $macros->{'$HOSTDURATION$'} : 0;

--- a/lib/Thruk/Backend/Provider/Livestatus.pm
+++ b/lib/Thruk/Backend/Provider/Livestatus.pm
@@ -524,7 +524,7 @@ sub get_services {
             host_active_checks_enabled host_address host_alias host_checks_enabled host_check_type
             host_latency host_plugin_output host_perf_data host_current_attempt host_check_command
             host_comments host_groups host_has_been_checked host_icon_image_expanded host_icon_image_alt
-            host_is_executing host_is_flapping host_name host_notes_url_expanded
+            host_is_executing host_is_flapping host_notes host_name host_notes_url_expanded
             host_notifications_enabled host_scheduled_downtime_depth host_state host_accept_passive_checks
             host_last_state_change
             icon_image icon_image_alt icon_image_expanded is_executing is_flapping


### PR DESCRIPTION
This patch will add host_notes to the default livestatus query. The host_notes will be shown in the json output.
I' m not sure if the change to the Manager.pm is necessary.
Fix for #781 