### PR TITLE
fix downtime filter

### DIFF
--- a/lib/Thruk/Utils/RecurringDowntimes.pm
+++ b/lib/Thruk/Utils/RecurringDowntimes.pm
@@ -88,6 +88,7 @@ sub get_downtimes_list {
     }
 
     # host and service filter
+    push @servicefilter, {  host_name => $host } if $host;
     push @servicefilter, { -and => [ { description => $service }, { host_name => $host} ] } if $service;
     push @hostfilter, { name => $host }                                                     if $host;
 

--- a/lib/Thruk/Utils/RecurringDowntimes.pm
+++ b/lib/Thruk/Utils/RecurringDowntimes.pm
@@ -88,9 +88,9 @@ sub get_downtimes_list {
     }
 
     # host and service filter
-    push @servicefilter, {  host_name => $host } if $host;
-    push @servicefilter, { -and => [ { description => $service }, { host_name => $host} ] } if $service;
-    push @hostfilter, { name => $host }                                                     if $host;
+    push @servicefilter, {  host_name => $host }     if $host;
+    push @servicefilter, { description => $service } if $service;
+    push @hostfilter, { name => $host }              if $host;
 
     my($hosts, $services, $hostgroups, $servicegroups) = ({},{},{},{});
     if($host || $service) {


### PR DESCRIPTION
[get_downtimes_list](https://github.com/sni/Thruk/blob/3e7443814e01297c13078d7f8687d2bbfec3f01c/lib/Thruk/Utils/RecurringDowntimes.pm#L75) ignores the _host_ parameter for the service filter if _service_ parameter is not defined. If the host parameter is defined only the service related to such host should be considered. This is critical for performance because the filter of _get_services_ will be empty. 