### PR TITLE
Updates to graphing documentation

### DIFF
--- a/docs/documentation/graphing.asciidoc
+++ b/docs/documentation/graphing.asciidoc
@@ -50,8 +50,6 @@ Make sure to include the updated file instead of the default. Either by editing 
 
 Then add the path used for cookies to your local thruk configuration. You can add the following line to '/etc/thruk/thruk.conf'.
 
-ex.:
-
 ------
 cookie_path = /
 ------

--- a/docs/documentation/graphing.asciidoc
+++ b/docs/documentation/graphing.asciidoc
@@ -48,7 +48,7 @@ RewriteCond %{REQUEST_URI}           ^/(thruk|pnp4nagios)
 
 Make sure to include the updated file instead of the default. Either by editing 'thruk_cookie_auth_vhost.conf' or your custom virtual host configuration.
 
-Then add the path used for cookies to your local thruk configuration. This should be the default anyway but just to make sure.
+Then add the path used for cookies to your local thruk configuration. You can add the following line to '/etc/thruk/thruk.conf'.
 
 ex.:
 


### PR DESCRIPTION
The graphing documentation previously stated that cookie_path = / should be enabled by default. However, on an out of the box installation, this is not default. I added the path of the file to change and removed the "ex:" to make this more in line with the how-to format.