### PR TITLE
Update bp.tt to restrict view permissions

### DIFF
--- a/plugins/plugins-available/business_process/templates/bp.tt
+++ b/plugins/plugins-available/business_process/templates/bp.tt
@@ -20,6 +20,7 @@
     [% END %]
   </tr>
   [% FOREACH bp IN bps %]
+  [% IF c.check_cmd_permissions('host', bp.name) %]
   [% SET rowclass = 'statusOdd'  IF loop.even %]
   [% SET rowclass = 'statusEven' IF loop.odd %]
   [% statusClass = 'statusUNKNOWN' %]
@@ -68,6 +69,7 @@
     </td>
     [% END %]
   </tr>
+  [% END %]
   [% END %]
 </table>
 </div>


### PR DESCRIPTION
Added filtering of BPs listed based on permissions to view the Thruk generated placeholder.
The even/odd coloring of rows may get mixed up in some cases since it simply skips BPs on its iteration. 