### PR TITLE
Fix reports from url

### DIFF
--- a/plugins/plugins-available/reports2/lib/Thruk/Utils/Reports/Render.pm
+++ b/plugins/plugins-available/reports2/lib/Thruk/Utils/Reports/Render.pm
@@ -289,7 +289,7 @@ sub get_url {
     if($url =~ m/^https?:\/\/([^\/]+)/mx && $c->stash->{'param'}->{'pdf'}) {
         Thruk::Utils::External::update_status($ENV{'THRUK_JOB_DIR'}, 80, 'converting') if $ENV{'THRUK_JOB_DIR'};
         my $phantomjs = $c->config->{'Thruk::Plugin::Reports2'}->{'phantomjs'} || 'phantomjs';
-        my $cmd = $c->config->{home}.'/html2pdf.sh "'.$url.'" "'.$c->stash->{'attachment'}.'.pdf" "" "'.$phantomjs.'"';
+        my $cmd = $c->config->{home}.'/script/html2pdf.sh "'.$url.'" "'.$c->stash->{'attachment'}.'.pdf" "" "'.$phantomjs.'"';
         local $ENV{PHANTOMJSSCRIPTOPTIONS} = '--cookie=thruk_auth,'.$sessionid;
         `$cmd`;
         move($c->stash->{'attachment'}.'.pdf', $c->stash->{'attachment'}) or die('move '.$c->stash->{'attachment'}.'.pdf to '.$c->stash->{'attachment'}.' failed: '.$!);


### PR DESCRIPTION
When creating a report from an url I get this error:
```
move .../thruk/var/reports/5.dat.pdf to .../thruk/var/reports/5.dat failed: No such file or directory at .../thruk/plugins/plugins-enabled/reports2/lib/Thruk/Utils/Reports/Render.pm line 312.
```
I have discovered that the `5.dat.pdf` is not created because the script `html2pdf.sh`, that is responsible for creating it, is not located in the project home but under the `script/` dir.
