### PR TITLE
Adding logcache_pxc_strict_mode

### DIFF
--- a/docs/documentation/configuration.asciidoc
+++ b/docs/documentation/configuration.asciidoc
@@ -1353,7 +1353,21 @@ ex.:
   logcache_import_command = .../importscript.sh
 
 
+=== logcache_pxc_strict_mode
+If you are using a mysql database with galera replication such as MariaDB Cluster,
+Percona XtraDB Cluster or Galera Cluster it is a good idea to avoid locks and
+optimize/repair table statements since they are not properly replicated.
 
+Especially in Percona XtraDB Cluster > 5.6 the default setting of pxc_strict_mode
+will disable locks all togheter.
+
+This setting will make the logcache work in that case. More information about
+pxc_strict_mode available here:
+  - link:https://www.percona.com/doc/percona-xtradb-cluster/LATEST/features/pxc-strict-mode.html[Percona documentation]
+
+ex.:
+
+  logcache_pxc_strict_mode = 1
 
 === delay_pages_after_backend_reload
 

--- a/lib/Thruk/Backend/Provider/Mysql.pm
+++ b/lib/Thruk/Backend/Provider/Mysql.pm
@@ -1914,9 +1914,10 @@ sub _import_logcache_from_file {
         print "\n" if $verbose;
     }
 
-    _release_write_locks($dbh) unless $c->config->{'logcache_pxc_strict_mode'};
-
-    print "it is recommended to run logcacheoptimize after importing logfiles.\n" if $verbose;
+    unless ($c->config->{'logcache_pxc_strict_mode'}) {
+        _release_write_locks($dbh);
+        print "it is recommended to run logcacheoptimize after importing logfiles.\n" if $verbose;
+    }
 
     return $log_count;
 }


### PR DESCRIPTION
Galera based replication does not work well with full table locks so this pull request adds a possiblity to disable table locks, it also disables repair and optimize table which should never be neccessary when using an innodb like engine (which you are doing if you are running galera replication), but will add lots of performance penalties. 