### PR TITLE
Allow resolving of variables with underscores (eg: $WMI_INI_DIR$)

### DIFF
--- a/lib/Thruk/Utils.pm
+++ b/lib/Thruk/Utils.pm
@@ -737,7 +737,7 @@ sub read_resource_file {
     $macros   = {} unless defined $macros;
     open(my $fh, '<', $file) or die("cannot read file ".$file.": ".$!);
     while(my $line = <$fh>) {
-        if($line =~ m/^\s*(\$[A-Z0-9]+\$)\s*=\s*(.*)$/mx) {
+        if($line =~ m/^\s*(\$[A-Z0-9_]+\$)\s*=\s*(.*)$/mx) {
             $macros->{$1}   = $2;
             $comments->{$1} = $lastcomment;
             $lastcomment    = "";


### PR DESCRIPTION
issue  #836 