### PR TITLE
Fix authorized_for_read_only role removal regression

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1767,6 +1767,7 @@ t/105-thruk-utils-ssi.t
 t/106-thruk_context.t
 t/107-thruk_utils_avail.t
 t/108-thruk_utils_status.t
+t/110-thruk_authentication_user.t
 t/150-config-sitepanel.t
 t/200-view_Excel.t
 t/200-view_GD.t

--- a/lib/Thruk/Authentication/User.pm
+++ b/lib/Thruk/Authentication/User.pm
@@ -145,9 +145,9 @@ sub new {
         push(@{$self->{'roles'}}, qw/authorized_for_broadcasts authorized_for_reports authorized_for_business_processes/);
     }
 
-    # Does this user have all roles?
-    if (@{$self->{'roles'}} == @{$possible_roles}) {
-        # Yes he/she does. Remove read only role
+    # Is this user an admin?
+    if ($self->check_user_roles('admin')) {
+        # Yes. Remove read only role
         $self->{'roles'} = [ grep({ $_ ne 'authorized_for_read_only' } @{$self->{'roles'}}) ];
     }
 

--- a/t/110-thruk_authentication_user.t
+++ b/t/110-thruk_authentication_user.t
@@ -1,0 +1,84 @@
+#!/usr/bin/env perl
+
+package FakeContext;
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %args) = @_;
+
+    return bless({ user => $args{user}, roles => $args{roles}}, $class);
+}
+
+sub config {
+    my $this = shift;
+
+    return {
+        cgi_cfg => { map({ $_ => $this->{user} } @{$this->{roles}}) },
+    };
+}
+
+sub env {
+    return {};
+}
+
+sub req {
+    return $_[0];
+}
+
+sub header {
+    return '';
+}
+
+sub stash {
+    return {};
+}
+
+package main;
+
+use warnings;
+use strict;
+use utf8;
+use Test::More;
+use Thruk::Utils;
+
+BEGIN {
+    plan tests => 4;
+
+    use lib('t');
+    require TestUtils;
+    import TestUtils;
+}
+
+use_ok('Thruk');
+use_ok('Thruk::Authentication::User');
+
+# Admin user with ro sprinkled in
+my $admin = Thruk::Authentication::User->new(
+    FakeContext->new(
+        user => 'admin',
+        roles => [qw/
+                    authorized_for_configuration_information
+                    authorized_for_system_commands
+                    authorized_for_read_only
+                /],
+    ),
+    'admin'
+);
+
+is(grep({ $_ eq 'authorized_for_read_only' } @{$admin->{roles}}), 0, 'ro removed from admin');
+
+# Non-admin with ro sprinkled id
+my $nonadmin = Thruk::Authentication::User->new(
+    FakeContext->new(
+        user => 'nonadmin',
+        roles => [qw/
+                    authorized_for_system_commands
+                    authorized_for_read_only
+                /],
+    ),
+    'nonadmin'
+);
+
+is(grep({ $_ eq 'authorized_for_read_only' } @{$nonadmin->{roles}}), 1, 'ro in nonadmin');


### PR DESCRIPTION
PR #863 broke the effects of #854 so that _authorized_for_read_only_ was never actually removed.
This fixes that and adds a test case so that it may never happen again.