### PR TITLE
Provide in Availability Report an action link to access Host/Service details page

### DIFF
--- a/templates/avail_report_host.tt
+++ b/templates/avail_report_host.tt
@@ -15,6 +15,7 @@
                 <a href='status.cgi?host=[% host | uri %]'>View Status Detail For This Host</a><br>
                 <a href='history.cgi?host=[% host | uri %]'>View Alert History For This Host</a><br>
                 <a href='notifications.cgi?host=[% host | uri %]'>View Notifications For This Host</a><br>
+                <a href='extinfo.cgi?type=1&amp;host=[% host | uri %]'>View Information For This Host</a><br>
               </td>
             </tr>
           </table>

--- a/templates/avail_report_service.tt
+++ b/templates/avail_report_service.tt
@@ -15,6 +15,7 @@
                 [% IF use_feature_histogram %]<a href='histogram.cgi?host=[% host | uri %]&amp;service=[% service %]&amp;t1=[% start %]&amp;t2=[% end %]&amp;assumestateretention=[% assumestateretention %]'>View Alert Histogram For This Service</a><br>[% END %]
                 <a href='history.cgi?host=[% host | uri %]&amp;service=[% service | uri %]'>View Alert History For This Service</a><br>
                 <a href='notifications.cgi?host=[% host | uri %]&amp;service=[% service | uri %]'>View Notifications For This Service</a><br>
+                <a href='extinfo.cgi?type=2&amp;host=[% host | uri %]&service=[% service %]'>View Information For This Service</a><br>
               </td>
             </tr>
           </table>


### PR DESCRIPTION
Within the availability report (avail.cgi) of a Host or Service the section "Log Entries" highlights the status changes. Users often plan Downtimes or Acknowledgements and register additional information as a Comment on the Host or Service. Having a direct action link to reach the "Host Information" or "Service Information" page simplifies life.
NB: Some users even integrate their ticketing system and register the Ticket # as a comment on the host.