### PR TITLE
Update regex filter in history.pm

### DIFF
--- a/lib/Thruk/Controller/history.pm
+++ b/lib/Thruk/Controller/history.pm
@@ -125,7 +125,7 @@ sub index {
     # add system messages
     unless($nosystem) {
         push @prop_filter, { message => { '~' => 'starting\.\.\.' }};
-        push @prop_filter, { message => { '~' => 'shutting\ down\.\.\.' }};
+        push @prop_filter, { message => { '~' => 'shutting down\.\.\.' }};
     }
 
     # join type filter together


### PR DESCRIPTION
because we don't need to backslash the space character as it will generate a 400 error in livestatus : 
local livestatus: ERROR: The request contains an invalid header. - Filter: Unexpected escape character.