### PR TITLE
config /etc/thruk/naglint.conf was ignored

### DIFF
--- a/plugins/plugins-available/conf/lib/Monitoring/Config.pm
+++ b/plugins/plugins-available/conf/lib/Monitoring/Config.pm
@@ -2578,7 +2578,7 @@ sub read_rc_file {
     my($self, $file) = @_;
     my @rcfiles  = glob($file || '~/.naglintrc /etc/thruk/naglint.conf '.(defined $ENV{'OMD_ROOT'} ? $ENV{'OMD_ROOT'}.'/etc/thruk/naglint.conf' : ''));
     for my $f (@rcfiles) {
-        if(defined $f || -r $f) {
+        if(defined $f && -r $f) {
             $file = $f;
             last;
         }


### PR DESCRIPTION
I tried to modify the sort order which used by naglint. I found out the /etc/thruk/naglint.conf was ignored. I fixed it for me with the following commit. 