### PR TITLE
fix hostdata for mobile plugin

### DIFF
--- a/lib/Thruk/Controller/cmd.pm
+++ b/lib/Thruk/Controller/cmd.pm
@@ -195,7 +195,7 @@ sub index {
                 return $c->detach('/error/index/7');
             }
             #my( $host, $service, $backend )...
-            my( $host, undef, $backend ) = split /;/mx, $hostdata;
+            my( $host, $backend ) = split /;/mx, $hostdata;
             my @backends                 = split /\|/mx, defined $backend ? $backend : '';
             $c->stash->{'lasthost'}      = $host;
             $c->req->parameters->{'cmd_typ'} = $cmd_typ;


### PR DESCRIPTION
When using the mobile plugin, the acknowledge action currently doesn't work. The data passed to `$hostdata` is "hostname;backend", just two item separated by semi colon, not three. (Three is correct for services, where the data is "hostname;service;backend").