### PR TITLE
Change use_timezone to server_timezone in FAQ due to depreciation 

### DIFF
--- a/docs/documentation/faq.asciidoc
+++ b/docs/documentation/faq.asciidoc
@@ -37,8 +37,8 @@ with the fastcgi version.
 
 === All dates and times are displayed with the wrong timezone
 
-Try to set the use_timezone configuration option in your
-thruk_local.conf
+Set the 'server_timezone' configuration option in your thruk_local.conf.
+See the link:configuration.html#server_timezone[configuration page] for details.
 
 
 


### PR DESCRIPTION
use_timezone was deprecated in a17cac562639cc930176eec213603aba6bd4ba98
This changes use_timezone to server_timezone in the FAQ.
Also adds a link to the relevant section on the configuration page.