### PR TITLE
allow space after function name in js action menus

### DIFF
--- a/lib/Thruk/Utils/Filter.pm
+++ b/lib/Thruk/Utils/Filter.pm
@@ -533,7 +533,7 @@ sub get_action_menu {
         if($sourcefile && $sourcefile =~ m/\.js$/mx) {
             # js file
             $c->stash->{'checked_action_menus'}->{$menu}->{'type'} = 'js';
-            if($c->stash->{'checked_action_menus'}->{$menu}->{'data'} =~ m/function\s+([^\(\s]+)\(/mx) {
+            if($c->stash->{'checked_action_menus'}->{$menu}->{'data'} =~ m/function\s+([^\(\s]+)\s*\(/mx) {
                 $c->stash->{'checked_action_menus'}->{$menu}->{'function'} = $1;
             }
         } else {


### PR DESCRIPTION
some javascript formatting styles have a space after the function name like this:

```js
function hostmenu (data){
        return({...});
}
```

This breaks the assumption made by the regex, that the opening parenthesis of the parameter list immediately follows the function name, and as the character group excludes spaces the space is also not used in the function name.