### PR TITLE
action_url: document why the quoting looks a bit strange

### DIFF
--- a/docs/documentation/graphing.asciidoc
+++ b/docs/documentation/graphing.asciidoc
@@ -27,6 +27,9 @@ define service {
 }
 ------
 
+The value is inserted verbatim into an +<a href=\'action_url\'>+, so the strange quoting is a trick
+to add extra parameters in HTML.
+
 [TIP]
 .templates
 =======


### PR DESCRIPTION
it may be necessary to look over the code for instances where the
action_url is enclosed in `""` rather than `''`, e.g., in
plugins/plugins-available/panorama/lib/Thruk/Controller/panorama.pm