### PR TITLE
add nginx-core to debian dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,8 +23,8 @@ Package: thruk-base
 Architecture: any
 Depends: ${shlibs:Depends}, ${perl:Depends}, ${extra:Depends},
          libthruk (>=2.38),
-         apache2 | nginx-light | nginx-full | nginx-extras,
-         libapache2-mod-fcgid | nginx-light | nginx-full | nginx-extras,
+         apache2 | nginx-light | nginx-full | nginx-extras | nginx-core,
+         libapache2-mod-fcgid | nginx-light | nginx-full | nginx-extras | nginx-core,
          cron, logrotate, liblwp-protocol-https-perl
 Provides: thruk
 Replaces: thruk (<< 2.00)


### PR DESCRIPTION
In addition to the Nginx package variants in Debian, Ubuntu has an additional variant called `nginx-core`. In contrast to the other variants this is part of Ubuntu Core and not Universe, which means that there is extended security support provided by Canonical. At the moment installing Thruk on a system using `nginx-core` means that it will be replaced by `nginx-light`. Which in turn means that you might miss out on security updates in the future.