### PR TITLE
Removed Monitoring Portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Support
 -------
 
   * Ask a question on [Stack Overflow](https://stackoverflow.com/questions/tagged/thruk)
-  * Discuss on the [Monitoring Portal](http://www.monitoring-portal.org/wbb/index.php?page=Board&boardID=106) (german / english).
   * Mailing list on [Google Groups](https://groups.google.com/group/thruk).
   * File a bug in [GitHub Issues](https://github.com/sni/Thruk/issues).
   * [Tweet](https://twitter.com/ThrukGUI/) us with other feedback.


### PR DESCRIPTION
monitoring-portal.org has been shut down

Due to continued GDPR claims for removing content from the site, the owner decided to shut down the forum.

See the Tweet by @dnsmichi.