### PR TITLE
Update omd-multisite.asciidoc

### DIFF
--- a/docs/documentation/omd-multisite.asciidoc
+++ b/docs/documentation/omd-multisite.asciidoc
@@ -91,7 +91,7 @@ We will log into Thruk on each site and create service check for the localhost.
 Within Thruk:
 
 `Config Tool > Object Settings > Create a new host > `
-Using the below as an example, create a simple check for each site.
+Using the following as an example, create a simple check for each site.
 Be sure to hit `apply` and then `save & reload` when you are finished.
 
 [source]


### PR DESCRIPTION
'below' is NOT a noun and this usage breaks Adjective Order.  Using 'the following', implying 'the following paragraph', is better than using 'the paragraph below' (proper preposition here) as it just flows better.