### PR TITLE
allow cron|bcron|systemd-cron (not cron|bcron)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,7 @@ Depends: ${shlibs:Depends}, ${perl:Depends}, ${extra:Depends},
          libthruk (>=2.44.2),
          apache2 | nginx-light | nginx-full | nginx-extras | nginx-core,
          libapache2-mod-fcgid | nginx-light | nginx-full | nginx-extras | nginx-core,
-         cron, logrotate, liblwp-protocol-https-perl
+         cron-daemon, logrotate, liblwp-protocol-https-perl
 Provides: thruk
 Replaces: thruk (<< 2.00)
 Breaks: thruk (<< 2.00)


### PR DESCRIPTION
11:42 <twb> cb: thruk package incorrectly depends on "cron" instead of "cron-daemon", forcing uninstall of systemd-cron, and fucking up all my logging of cron jobs :/
11:42 <cb> twb: not only that one. also zfs-auto-snapshot has this problem.
11:42 <twb> Which is ironic because they test with systemd-cron https://github.com/sni/Thruk/blob/2998b755321a8e74382419ebb916c7c470725d52/t/scenarios/citest/citest/Dockerfile
11:43 <cb> o_0

Plain vixie cron will work with "Depends: cron-daemon" since at least 2010: https://salsa.debian.org/debian/cron/-/commit/c95e09bf01b55a671c3abdd88eacc1e4edcfc9ff