### PR TITLE
Avoid linux-specific bash absolute path

### DIFF
--- a/docs/documentation/dashboard_scripted.asciidoc
+++ b/docs/documentation/dashboard_scripted.asciidoc
@@ -333,7 +333,7 @@ $dashboard->{'tab'}->{'xdata'}->{'refresh'} = 10;
 This example is a simple shell script which has label with the current time.
 
 ------
-#!/bin/bash
+#!/usr/bin/env bash
 # title:  Scripted Bash
 # user:   thrukadmin
 # groups: [{"*" : "read-only"}]

--- a/examples/config_tool_git_checkin
+++ b/examples/config_tool_git_checkin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # config_tool_git_checkin - save hook for thruk config tool to commit changes to git repository
 #

--- a/examples/contacts2csv
+++ b/examples/contacts2csv
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/examples/dump_services
+++ b/examples/dump_services
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/examples/get_logs
+++ b/examples/get_logs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/examples/list_hosts
+++ b/examples/list_hosts
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/examples/objectcache2csv
+++ b/examples/objectcache2csv
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/examples/query2testobjects
+++ b/examples/query2testobjects
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/examples/remove_duplicates
+++ b/examples/remove_duplicates
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/examples/trigger_eventhandler_at_downtime_end
+++ b/examples/trigger_eventhandler_at_downtime_end
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/examples/worker_command_tester
+++ b/examples/worker_command_tester
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/get_version
+++ b/get_version
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ ! -e .git ]; then
   echo "not in an development environment, no .git directory found" >&2

--- a/plugins/plugins-available/panorama/scripts/disable_debug.sh
+++ b/plugins/plugins-available/panorama/scripts/disable_debug.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for file in root/js/*.js templates/*.tt; do
     sed -i '/TP.tracelog.*console.*temporary debug/d' $file

--- a/plugins/plugins-available/panorama/scripts/enable_debug.sh
+++ b/plugins/plugins-available/panorama/scripts/enable_debug.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for file in root/js/*.js templates/*.tt; do
     perl -i -pe 's/^(.*?\s+(\w+)[=: ]+function\([^(]*\)\ *\{)$/$1\nif(TP.tracelog) { console.log("$2"); } \/\/ temporary debug/g' $file

--- a/root/thruk/vendor/extjs_clean.sh
+++ b/root/thruk/vendor/extjs_clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "x$1" = "x" -o ! -d "$1" ]; then
   echo "usage: $0 <extjsfolder>"

--- a/script/check_thruk_rest
+++ b/script/check_thruk_rest
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/script/generate_timeperiod_transitions.pl
+++ b/script/generate_timeperiod_transitions.pl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/script/grafana_export.sh
+++ b/script/grafana_export.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script exports a grafana graph and stores it in a temp file.
 #

--- a/script/html2pdf.sh
+++ b/script/html2pdf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # usage:
 #

--- a/script/install_puppeteer.sh
+++ b/script/install_puppeteer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # usage: ./install_puppeteer.sh
 #

--- a/script/nagexp
+++ b/script/nagexp
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/script/nagimp
+++ b/script/nagimp
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/script/naglint
+++ b/script/naglint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/script/pnp_export.sh
+++ b/script/pnp_export.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script exports a pnp graph and stores it in a temp file.
 #

--- a/script/reenable_actions
+++ b/script/reenable_actions
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/script/templates_cleanup.pl
+++ b/script/templates_cleanup.pl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/script/theme-icons-update.pl
+++ b/script/theme-icons-update.pl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/script/theme-obsolete-images.pl
+++ b/script/theme-obsolete-images.pl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/script/thruk
+++ b/script/thruk
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/script/thruk_auth
+++ b/script/thruk_auth
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/script/thruk_fastcgi_server.sh
+++ b/script/thruk_fastcgi_server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 ### BEGIN INIT INFO
 # Provides:          thruk_fastcgi

--- a/script/thruk_format_perl_modules
+++ b/script/thruk_format_perl_modules
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/script/thruk_link_images.sh
+++ b/script/thruk_link_images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$1" = "" ]; then
     echo "usage: $0 <image>"

--- a/script/thruk_optimize_images.sh
+++ b/script/thruk_optimize_images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # usage: ./script/thruk_optimize_images.sh [<image>]
 #

--- a/script/thruk_set_standard_header
+++ b/script/thruk_set_standard_header
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 test -f support/standard_script_header
 

--- a/script/thruk_update.sh
+++ b/script/thruk_update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #export PERL_AUTOINSTALL_PREFER_CPAN=1
 export PERL_MM_USE_DEFAULT=1

--- a/script/thruk_update_docs.sh
+++ b/script/thruk_update_docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 `which asciidoc > /dev/null 2>&1`;
 if [ "$?" -ne "0" ]; then

--- a/script/thruk_version.sh
+++ b/script/thruk_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # usage: ./script/thruk_version.sh
 #

--- a/support/convert_old_datafile.pl
+++ b/support/convert_old_datafile.pl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/support/fcgid_env.sh
+++ b/support/fcgid_env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # set thruk environment
 # and run fastcgi server
 

--- a/support/icinga2_ido_fetchlogs.sh
+++ b/support/icinga2_ido_fetchlogs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 INSTANCE_ID=${INSTANCE_ID:-1}
 

--- a/support/makecert.sh
+++ b/support/makecert.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # call this script with an email address (valid or not).
 # like:
 # ./makecert.sh <common name> <email>

--- a/support/panorama2img
+++ b/support/panorama2img
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # usage:
 #

--- a/support/standard_script_header
+++ b/support/standard_script_header
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # read rc files if exist
 unset PROFILEDOTD

--- a/t/scenarios/_common/ansible/install_role.sh
+++ b/t/scenarios/_common/ansible/install_role.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ROLE=$1
 shift

--- a/t/scenarios/_common/ansible/roles/local_tests/files/local_test.sh
+++ b/t/scenarios/_common/ansible/roles/local_tests/files/local_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 VERBOSE=0
 if [ "x$1" != "x" ]; then

--- a/t/scenarios/auth_krb5/vnc/ff_profile.sh
+++ b/t/scenarios/auth_krb5/vnc/ff_profile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if test -e .mozilla; then
     echo ".mozilla does already exist"

--- a/t/scenarios/auth_krb5/vnc/kinit.sh
+++ b/t/scenarios/auth_krb5/vnc/kinit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for x in $(seq 100); do
     yes omd | kinit -f omdadmin >/dev/null 2>&1

--- a/t/scenarios/citest/extra_prepare.sh
+++ b/t/scenarios/citest/extra_prepare.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/t/scenarios/citest/test.sh
+++ b/t/scenarios/citest/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ $(whoami) != "naemon" ]; then
     exec sudo su naemon -c "$0 $*"

--- a/t/scenarios/cli_api/t/reschedule_all.sh
+++ b/t/scenarios/cli_api/t/reschedule_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 thruk host list | \
   while read host; do

--- a/t/scenarios/cli_api/t/test.sh
+++ b/t/scenarios/cli_api/t/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 VERBOSE=$1
 if [ "x$VERBOSE" = "x" ]; then

--- a/t/scenarios/cli_api/t/test_root.sh
+++ b/t/scenarios/cli_api/t/test_root.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 VERBOSE=$1
 if [ "x$VERBOSE" = "x" ]; then

--- a/t/scenarios/cli_api/test.sh
+++ b/t/scenarios/cli_api/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 FLAGS=""
 if [ ! -t 0 ]; then

--- a/t/scenarios/cluster_e2e/scale
+++ b/t/scenarios/cluster_e2e/scale
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "x$1" = "x" ]; then
   echo "usage: $0 <target number>"

--- a/t/scenarios/lmd_federation_e2e/docker_tc.sh
+++ b/t/scenarios/lmd_federation_e2e/docker_tc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #
 #

--- a/t/scenarios/logfile_cache_icinga2_ido_e2e/omd/add_user.sh
+++ b/t/scenarios/logfile_cache_icinga2_ido_e2e/omd/add_user.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY 'root';" | mysql
 echo "FLUSH PRIVILEGES;" | mysql

--- a/t/scenarios/pentest_arachni/t/test.sh
+++ b/t/scenarios/pentest_arachni/t/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd /arachni
 

--- a/t/timed_test.sh
+++ b/t/timed_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for test in t/*.t t/xt/*/*.t; do
     out=$(TEST_AUTHOR=1 PERL_DL_NONLAZY=1 perl "-MExtUtils::Command::MM" "-e" "test_harness(0, 'inc', 'blib/lib', 'blib/arch')" $test | grep -v '^All tests')


### PR DESCRIPTION
On non-linux systems, bash can be installed in other directories, for example /usr/local/bin/bash on FreeBSD.