### PR TITLE
Suppress warnings about uninitialized value

### DIFF
--- a/lib/Thruk/Utils/CLI/Maintenance.pm
+++ b/lib/Thruk/Utils/CLI/Maintenance.pm
@@ -97,7 +97,7 @@ sub clean_old_user_files {
     my $old_timeout    = time() - (86400 * 365); # remove unused logins after one year
 
     my $sdir = $c->config->{'var_path'}.'/users';
-    return unless -d $sdir."/.";
+    return($total, $removed) unless -d $sdir."/.";
     opendir(my $dh, $sdir) or die "can't opendir '$sdir': $!";
     for my $entry (readdir($dh)) {
         next if $entry eq '.' or $entry eq '..';


### PR DESCRIPTION
If directory doesn't exist the maintainance script warning about uninitialized value(s).

```
root@e080ba9fd208:/# /usr/bin/thruk maintenance
running maintenance jobs:
  - sessions            : removed     0 /     0 old sessions
Use of uninitialized value in sprintf at /usr/share/thruk/lib/Thruk/Utils/Log.pm line 138.
Use of uninitialized value in sprintf at /usr/share/thruk/lib/Thruk/Utils/Log.pm line 138.
  - user files          : removed     0 /     0 unused user files
  - jobs                : removed     0 /     0 old job folders
maintenance complete
```