### PR TITLE
avoid error when sql_mode=only_full_group_by

### DIFF
--- a/lib/Thruk/Backend/Provider/Mysql.pm
+++ b/lib/Thruk/Backend/Provider/Mysql.pm
@@ -561,18 +561,7 @@ sub get_logs {
         # fetch real number of entries here
         my $sql = '
         SELECT
-            count(*),
-            l.time as time,
-            l.class as class,
-            l.type as type,
-            l.state as state,
-            l.state_type as state_type,
-            IFNULL(h.host_name, "") as host_name,
-            IFNULL(s.service_description, "") as service_description,
-            IFNULL(c.name, "") as contact_name,
-            l.message as message,
-            "'.$prefix.'" as peer_key
-            '.$extra_columns.'
+            count(*)
         FROM
             `'.$prefix.'_log` l
             LEFT JOIN `'.$prefix.'_host` h ON l.host_id = h.host_id


### PR DESCRIPTION
Running logcache on MySQL/Percona Server 8 which has a stricter sql mode.

When browsing through the log messages for a host, the results are empty if there are more results than the pagination setting. E.g. '100 per page' => if there are 101 results, the list is empty and the backend shows up as in error state at the top. 

Setting pagination to 'all on one page' shows the correct results because the query is not executed then: https://github.com/sni/Thruk/blob/48da5c28450c0e70292518c8787bebaf7166a842/lib/Thruk/Backend/Provider/Mysql.pm#L559-L586

Cfr. https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sql-mode-setting

```
DBD::mysql::db selectall_arrayref failed: In aggregated query without GROUP BY,
expression #2 of SELECT list contains nonaggregated column 'thruk_logs.l.time';
this is incompatible with sql_mode=only_full_group_by
```

It seems only the `count(*)` result is used, so the other columns can be omitted, avoiding the error.