### PR TITLE
Prevent XSS attack by sanitizing the content of the textbox in _filter_advanced.tt

### DIFF
--- a/templates/_filter_advanced.tt
+++ b/templates/_filter_advanced.tt
@@ -5,4 +5,4 @@ rows="5"
 wrap="hard"
 name="[% paneprefix %]q"[% DEFAULT disabled = 0; IF disabled %] disabled[% END %]
 onfocus="initAutoCompleteQuery(this, queryCodeCompletions)"
->[% content %]</textarea>
+>[% content | html %]</textarea>


### PR DESCRIPTION
Prevent XSS attack by sanitizing the content of the textbox.

The Filter had a possibility for an XSS attack by appending the following to the url of any page utilizing the advanced filter:
"q=</textarea><img src=fake onerror=alert("XSS")>"

![image](https://github.com/sni/Thruk/assets/845133/be52701b-9199-41f7-a353-2995981d723e)

