### PR TITLE
Extend the list of options for spreading checks

### DIFF
--- a/docs/documentation/configuration.asciidoc
+++ b/docs/documentation/configuration.asciidoc
@@ -2141,6 +2141,16 @@ ex.:
 
 
 
+=== reschedule_spread
+Default spread of rescheduled checks in seconds. Default is none.
+Options are 0, 10, 30, 60, 300, 900, 1800, 3600.
+
+ex.:
+
+  reschedule_spread = 0
+
+
+
 === cmd_quick_status
 Configure which commands should be available as quick status commands.
 

--- a/lib/Thruk/Config.pm
+++ b/lib/Thruk/Config.pm
@@ -134,6 +134,7 @@ my $base_defaults = {
                 'use_expire'                    => 0,
                 'childoptions'                  => 0,
                 'hostserviceoptions'            => 0,
+                'reschedule_spread'             => 0,
     },
     'command_disabled'                      => [],
     'command_enabled'                       => [],

--- a/templates/_status_cmd_pane.tt
+++ b/templates/_status_cmd_pane.tt
@@ -175,14 +175,14 @@
               <tr><td class="pt-0 clickable" onclick="toggleCheckBox('opt1')">Force Check</td><td class="pt-0"><input type='checkbox' id="opt1" name='force_check'[% IF c.config.cmd_defaults.force_check %] checked[% END %]></td></tr>
               <tr><td class="pt-0">Spread Checks</td><td>
                 <select name="spread">
-                  <option value="0">No</option>
-                  <option value="10">10 Seconds</option>
-                  <option value="30">30 Seconds</option>
-                  <option value="60"> 1 Minute</option>
-                  <option value="300"> 5 Minutes</option>
-                  <option value="900"> 15 Minutes</option>
-                  <option value="1800"> 30 Minutes</option>
-                  <option value="3600"> 1 Hour</option>
+                  <option value="0"[% IF c.config.cmd_defaults.reschedule_spread == 0 %] selected[% END%]>No</option>
+                  <option value="10"[% IF c.config.cmd_defaults.reschedule_spread == 10 %] selected[% END%]>10 Seconds</option>
+                  <option value="30"[% IF c.config.cmd_defaults.reschedule_spread == 30 %] selected[% END%]>30 Seconds</option>
+                  <option value="60"[% IF c.config.cmd_defaults.reschedule_spread == 60 %] selected[% END%]> 1 Minute</option>
+                  <option value="300"[% IF c.config.cmd_defaults.reschedule_spread == 300 %] selected[% END%]> 5 Minutes</option>
+                  <option value="900"[% IF c.config.cmd_defaults.reschedule_spread == 900 %] selected[% END%]> 15 Minutes</option>
+                  <option value="1800"[% IF c.config.cmd_defaults.reschedule_spread == 1800 %] selected[% END%]> 30 Minutes</option>
+                  <option value="3600"[% IF c.config.cmd_defaults.reschedule_spread == 3600 %] selected[% END%]> 1 Hour</option>
                 </select>
               </td></tr>
             </table>

--- a/templates/_status_cmd_pane.tt
+++ b/templates/_status_cmd_pane.tt
@@ -180,6 +180,9 @@
                   <option value="30">30 Seconds</option>
                   <option value="60"> 1 Minute</option>
                   <option value="300"> 5 Minutes</option>
+                  <option value="900"> 15 Minutes</option>
+                  <option value="1800"> 30 Minutes</option>
+                  <option value="3600"> 1 Hour</option>
                 </select>
               </td></tr>
             </table>


### PR DESCRIPTION
I regularly find myself in the situation where 5 minutes is not enough for spreading a few thousand checks that are quite heavy to process. Worker load becomes way too high and everything grinds to a halt.

Spreading over 30 minutes works just fine in this case.