### PR TITLE
add support for proxy configuration for Oauth

### DIFF
--- a/docs/documentation/configuration.asciidoc
+++ b/docs/documentation/configuration.asciidoc
@@ -2058,6 +2058,7 @@ ex.:
       api_url       = https://oauthserver/oauth2/v1/userinfo      # API endpoint to retrieve user information from
       login_field   = login                                       # Hash key from userinfo to get the actual username from. If not set, Thruk will try 'login', then 'email'
       #enable_pkce  = 0                                           # enable oauth 2.1 pkce workflow if set to 1. Disable by default
+      #https_proxy = http://<server>:<port>                       # optional proxy to use for accessing URLs from above
     </provider>
   </auth_oauth>
 

--- a/lib/Thruk/Utils/OAuth.pm
+++ b/lib/Thruk/Utils/OAuth.pm
@@ -58,7 +58,12 @@ sub handle_oauth_login {
         }
         my $ua = Thruk::UserAgent->new({}, $c->config);
         $ua->default_header(Accept => "application/json");
-        _debug(sprintf("oauth login step2: fetching token from: %s", $auth->{'token_url'})) if Thruk::Base->debug;
+	if (defined $auth->{'https_proxy'}) {
+            $ua->proxy('https', $auth->{'https_proxy'});
+            _debug(sprintf("oauth login step2: fetching token from: %s (via proxy: %s)", $auth->{'token_url'}, $auth->{'https_proxy'})) if Thruk::Base->debug;
+        } else {
+            _debug(sprintf("oauth login step2: fetching token from: %s", $auth->{'token_url'})) if Thruk::Base->debug;
+        };
         my $token_data = {
             client_id       => $auth->{'client_id'},
             client_secret   => $auth->{'client_secret'},

--- a/thruk.conf
+++ b/thruk.conf
@@ -786,6 +786,7 @@ locked_message                    = account is locked, please contact an adminis
 #    token_url     = https://oauthserver/oauth2/v1/token
 #    api_url       = https://oauthserver/oauth2/v1/userinfo
 #    login_field   = login
+#    # https_proxy   = http://<server>:<port> # optional
 #  </provider>
 #</auth_oauth>
 


### PR DESCRIPTION
in internal environments it can be required to use a proxy to verify the token of an external provider, option added hereby