### PR TITLE
quick command select: prevent onmousedown event to fix double-click bug on dropdown

### DIFF
--- a/templates/_status_cmd_pane.tt
+++ b/templates/_status_cmd_pane.tt
@@ -42,7 +42,7 @@
           <th class="w-24">Command</th>
           <td class="relative">
             <input type='hidden' id="opt_persistent" name='persistent' value="comments">
-            <select name="quick_command" id="quick_command" onChange="check_selected_command(this.value)" class="w-full" onclick="toggleElement('command_select', null, true); jQuery(this).blur(); return false;">
+            <select name="quick_command" id="quick_command" onChange="check_selected_command(this.value)" class="w-full" onmousedown="event.preventDefault()" onclick="toggleElement('command_select', null, true); jQuery(this).blur(); return false;">
               [% FOREACH qc = quick_commands %]
                 [% IF qc == "-"; NEXT; END %]
                 [% IF !qc.defined("cls");  qc.cls  = ""; END %]


### PR DESCRIPTION
Fix for the issue #1502 

users had to click command selector dropdown twice to see dropdown items. first click focused on the dropdown menu , borders turning blue as if its selected, the second click actually showed the dropdown items.

users could reset this focus state by clicking somewhere empty in the quick commands popup. they would then have to do two clicks again to show the dropdown, first to regain focus and second to show the dropdown.

made some changes using deepseek and tested it on

Firefox 140.11.0esr and Chromium 148.0.7778.215 (Official Build) built on Debian GNU/Linux 13 (trixie) (64-bit)

Deepseek explanation:

onmousedown="event.preventDefault()" prevents the browser from starting the native ```<select>``` dropdown mechanism. The browser never tries to open its own popup or focus the element.


onclick="toggleElement(...)" fires normally since mousedown's preventDefault doesn't block click events. The add_body_close mechanism (which is designed to work with click events) works correctly.


The original onclick-only approach failed because modern Chrome/Safari intercept the click on ```<select>``` at a platform level before onclick fires.


The pure onmousedown approach failed because the click event then landed on the newly-shown overlay div, confusing the body-close mechanism. This combined approach addresses both problems.