### PR TITLE
improved the custom variable matcher

### DIFF
--- a/lib/Thruk/Utils.pm
+++ b/lib/Thruk/Utils.pm
@@ -1043,6 +1043,76 @@ sub check_custom_var_list {
 
 ########################################
 
+=head2 _build_custom_var_matcher
+
+  _build_custom_var_matcher($allowed_list)
+
+precomputes a lookup structure for fast custom variable matching
+
+=cut
+sub _build_custom_var_matcher {
+    my($allowed_list) = @_;
+    return {} unless $allowed_list && ref $allowed_list eq 'ARRAY';
+
+    my %exact;
+    my @regexes;
+    my @host_regexes;
+
+    for my $allow (@{$allowed_list}) {
+        my $name = $allow;
+        $name =~ s/^_//gmx;
+        if(CORE::index($name, '*') == -1) {
+            $exact{$name} = 1;
+        } else {
+            my $re = $name;
+            $re =~ s/\*/.*/gmx;
+            if($name =~ m/^host/mxi) {
+                push @host_regexes, qr/^$re$/mx;
+            } else {
+                push @regexes, qr/^$re$/mx;
+            }
+        }
+    }
+
+    return {
+        exact        => \%exact,
+        regexes      => \@regexes,
+        host_regexes => \@host_regexes,
+    };
+}
+
+########################################
+
+=head2 _cv_lookup
+
+  _cv_lookup($varname, $matcher)
+
+checks if a custom variable name is allowed using a precomputed matcher
+
+=cut
+sub _cv_lookup {
+    my($var, $matcher) = @_;
+    return unless $matcher;
+
+    my $varname = $var;
+    $varname =~ s/^_//gmx;
+
+    return 1 if $matcher->{exact}{$varname};
+
+    my $regexes;
+    if($varname =~ m/^host/mxi) {
+        $regexes = $matcher->{host_regexes};
+    } else {
+        $regexes = $matcher->{regexes};
+    }
+    for my $re (@{$regexes}) {
+        return 1 if $varname =~ $re;
+    }
+    return;
+}
+
+########################################
+
 =head2 set_allowed_rows_data
 
   set_allowed_rows_data($obj, $allowed, $allowed_list, $show_full_commandline, $has_conf_info)
@@ -1053,10 +1123,16 @@ set custom variables for host/service obj
 sub set_allowed_rows_data {
     my($obj, $allowed_all_cust, $allowed_list, $show_full_commandline, $has_conf_info) = @_;
 
+    my $cv_matcher;
+    if(!$allowed_all_cust && $allowed_list && ref $allowed_list eq 'ARRAY') {
+        $cv_matcher = _build_custom_var_matcher($allowed_list);
+    }
+    my $_is_allowed = $cv_matcher ? sub { _cv_lookup(shift, $cv_matcher) } : sub { check_custom_var_list(shift, $allowed_list) };
+
     if($obj->{'custom_variable_names'}) {
         $obj->{'custom_variables'} = get_custom_vars(undef, $obj);
         for my $key (@{$obj->{'custom_variable_names'}}) {
-            if($allowed_all_cust || check_custom_var_list($key, $allowed_list)) {
+            if($allowed_all_cust || $_is_allowed->($key)) {
                 $obj->{'_'.uc($key)} = $obj->{'custom_variables'}->{$key};
             } else {
                 delete $obj->{'custom_variables'}->{$key};
@@ -1075,7 +1151,7 @@ sub set_allowed_rows_data {
     if($obj->{'host_custom_variable_names'}) {
         $obj->{'host_custom_variables'} = get_custom_vars(undef, $obj, 'host_');
         for my $key (@{$obj->{'host_custom_variable_names'}}) {
-            if($allowed_all_cust || check_custom_var_list('_HOST'.uc($key), $allowed_list)) {
+            if($allowed_all_cust || $_is_allowed->('_HOST'.uc($key))) {
                 $obj->{'_HOST'.uc($key)} = $obj->{'host_custom_variables'}->{$key};
             } else {
                 delete $obj->{'host_custom_variables'}->{$key};


### PR DESCRIPTION
the older check_custom_var_list function had a for loop over allowed variables array, in the for loop it would check
- exact match
- regex match
- host_regex match for the variables that started with "HOST"

this check_custom_var_list function was called for every variable in set_allowed_rows_data

allowed variables are static during the lifetime, and this was not used for optimization.

this change makes the old function a fallback, and instead builds a faster matcher using the fact that allowed variables does not change.

at the start of set_allowed_rows_data, build a matcher struct. it iterates through the allowed variables array ONCE and builds a map of exact matches, array of regexes, array of host regexes. 

these matcher collections are retained throught  set_allowed_rows_data and used for every variable, unlike of older check_custom_var_list which iterates through them in every call

matching each variable is most likely faster

- presence check for exact matches use a map instead of iterating through array again
- regexes are not generated repadately, and instead read from their pregenerated arrays