### PR TITLE
Show server timezone on cron schedule forms

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3189,6 +3189,7 @@ templates/_common_js.tt
 templates/_common_js_bugs.tt
 templates/_common_js_files.tt
 templates/_cron_edit.tt
+templates/_cron_schedule_tz_header.tt
 templates/_csv_export.tt
 templates/_customvar_box.tt
 templates/_db_stats.tt

--- a/plugins/plugins-available/reports2/templates/reports_edit.tt
+++ b/plugins/plugins-available/reports2/templates/reports_edit.tt
@@ -145,12 +145,13 @@
             <tr>
               <th class="align-top">Schedule</th>
               <td colspan=2 class="p-1">
-                <table id="cron_entries" class="w-full">
+                [% PROCESS _cron_schedule_tz_header.tt %]
+                <table id="cron_entries" class="w-full" data-show-schedule-tz="1" data-cron-tz="[% c.config._server_timezone | html %]">
                   [% cr = { type => 'month', day => 1, week_day => '', hour => 0, minute => 0, cust => '' } %]
-                  [% PROCESS _cron_edit.tt nr=0 can_edit=1 %]
+                  [% PROCESS _cron_edit.tt nr=0 can_edit=1 show_schedule_tz=1 %]
                   [% FOREACH cr = r.send_types %]
-                      [% nr = loop.index + 1 %]
-                      [% PROCESS _cron_edit.tt can_edit=1 %]
+                    [% nr = loop.index + 1 %]
+                    [% PROCESS _cron_edit.tt can_edit=1 show_schedule_tz=1 %]
                   [% END %]
                   <tr>
                     <td colspan=4 onclick="add_cron_row('cron_entries'); return false;" class="min-w-[100px] whitespace-nowrap clickable hoverable rounded">
@@ -205,6 +206,9 @@
 </div>
 
 
+<script>
+  init_cron_schedule_tz();
+</script>
 <script>
 <!--
   var inp = jQuery('SELECT[name=template]');

--- a/root/thruk/javascript/thruk-3.28.js
+++ b/root/thruk/javascript/thruk-3.28.js
@@ -3552,14 +3552,124 @@ function cron_change_date(id) {
     } else {
         showElement('hour_select_'+nr);
     }
+    cron_schedule_tz_refresh();
+}
+
+/* Cron schedule TZ: HH:MM is server time; optional browser-equivalence preview. */
+function cron_schedule_tz_offset_ms(cronTz, browserTz) {
+    var d, cron, br;
+    if(!cronTz || !browserTz || cronTz === browserTz) {
+        return(0);
+    }
+    try {
+        d    = new Date();
+        cron = new Date(d.toLocaleString('en-US', { timeZone: cronTz }));
+        br   = new Date(d.toLocaleString('en-US', { timeZone: browserTz }));
+        return(Math.round((br.getTime() - cron.getTime()) / 60000) * 60000);
+    } catch(e) {
+        return(0);
+    }
+}
+
+function cron_schedule_tz_pad(n) {
+    n = parseInt(n, 10);
+    return((n < 10 ? '0' : '') + n);
+}
+
+function cron_schedule_tz_refresh() {
+    var tbl, cronTz, browserTz, offsetMs, rows, i, m, nr, type, typeSel, hEl, mEl;
+    var preview, suffix, h, mi, d, hasRows, needsDayHint, infoEl, dayHint;
+    tbl = document.getElementById('cron_entries');
+    if(!tbl || !tbl.getAttribute('data-show-schedule-tz')) {
+        return;
+    }
+    cronTz     = tbl.getAttribute('data-cron-tz') || '';
+    browserTz  = (typeof getBrowserTimezone === 'function' ? getBrowserTimezone() : '') || '';
+    offsetMs   = cron_schedule_tz_offset_ms(cronTz, browserTz);
+    hasRows    = false;
+    needsDayHint = false;
+    rows = tbl.querySelectorAll('tr[id^="send_pane_"]');
+    for(i = 0; i < rows.length; i++) {
+        m = rows[i].id.match(/^send_pane_(\d+)$/);
+        if(!m || rows[i].style.display === 'none' || parseInt(m[1], 10) < 1) {
+            continue;
+        }
+        hasRows = true;
+        nr      = m[1];
+        typeSel = document.getElementById('send_type_' + nr);
+        type    = typeSel ? typeSel.value : '';
+        if(type !== 'day') {
+            needsDayHint = true;
+        }
+        suffix = document.getElementById('cron_tz_suffix_' + nr);
+        if(suffix) {
+            suffix.style.display = (type === 'cust') ? 'none' : '';
+        }
+        preview = document.getElementById('cron_tz_preview_' + nr);
+        if(!preview) {
+            continue;
+        }
+        if(offsetMs === 0 || !browserTz) {
+            preview.style.display = 'none';
+            preview.textContent   = '';
+            continue;
+        }
+        preview.style.display = '';
+        if(type === 'cust') {
+            preview.textContent = 'Custom cron uses server timezone (' + cronTz + ').';
+            continue;
+        }
+        hEl = document.getElementById('send_hour_' + nr);
+        mEl = document.getElementById('send_minute_' + nr);
+        h   = hEl ? parseInt(hEl.value, 10) : 0;
+        mi  = mEl ? parseInt(mEl.value, 10) : 0;
+        d   = new Date();
+        d.setHours(h, mi, 0, 0);
+        d   = new Date(d.getTime() + offsetMs);
+        preview.textContent = cron_schedule_tz_pad(h) + ':' + cron_schedule_tz_pad(mi) +
+            ' server (' + cronTz + ') = ' +
+            cron_schedule_tz_pad(d.getHours()) + ':' + cron_schedule_tz_pad(d.getMinutes()) +
+            ' in your browser (' + browserTz + ')';
+    }
+    infoEl = document.getElementById('cron_schedule_tz_info');
+    if(infoEl) {
+        infoEl.style.display = hasRows ? '' : 'none';
+    }
+    dayHint = document.getElementById('cron_schedule_tz_dayhint');
+    if(dayHint) {
+        dayHint.style.display = (hasRows && needsDayHint) ? '' : 'none';
+    }
+}
+
+function init_cron_schedule_tz() {
+    var tbl = document.getElementById('cron_entries');
+    if(!tbl || !tbl.getAttribute('data-show-schedule-tz') || tbl._cronTzBound) {
+        return;
+    }
+    tbl._cronTzBound = true;
+    tbl.addEventListener('change', function(ev) {
+        if(ev.target && ev.target.name && ev.target.name.match(/^send_(hour|minute|type)_/)) {
+            cron_schedule_tz_refresh();
+        }
+    });
+    cron_schedule_tz_refresh();
 }
 
 /* remove a row */
 function delete_cron_row(el) {
     var row = el;
+    var m, preview;
     /* find first table row */
     while(row.parentNode != undefined && row.tagName != 'TR') { row = row.parentNode; }
+    m = row.id.match(/^send_pane_(\d+)$/);
+    if(m) {
+        preview = document.getElementById('send_pane_preview_' + m[1]);
+        if(preview) {
+            preview.parentNode.deleteRow(preview.rowIndex);
+        }
+    }
     row.parentNode.deleteRow(row.rowIndex);
+    cron_schedule_tz_refresh();
     return false;
 }
 
@@ -3596,6 +3706,21 @@ function add_cron_row(tbl_id) {
     var lastRowNr      = tblBody.rows.length - 1;
     var currentLastRow = tblBody.rows[lastRowNr];
     tblBody.insertBefore(newRow, currentLastRow);
+
+    /* optional TZ preview row (template send_pane_preview_0) */
+    var previewTpl = document.getElementById('send_pane_preview_0');
+    if(previewTpl) {
+        var newPreview = previewTpl.cloneNode(true);
+        replace_ids_and_names(newPreview, new_nr);
+        var previewAll = newPreview.getElementsByTagName('*');
+        for(var pi = -1, pl = previewAll.length; ++pi < pl;) {
+            replace_ids_and_names(previewAll[pi], new_nr);
+        }
+        newPreview.style.display = '';
+        tblBody.insertBefore(newPreview, currentLastRow);
+    }
+
+    cron_change_date('send_type_' + new_nr);
 }
 
 

--- a/templates/_cron_edit.tt
+++ b/templates/_cron_edit.tt
@@ -1,4 +1,4 @@
-<tr id="send_pane_[% nr %]"[% IF nr == 0 %] style="display:none"[% END %]>
+﻿<tr id="send_pane_[% nr %]"[% IF nr == 0 %] style="display:none"[% END %]>
   <td>
     <select name="send_type_[% nr %]" id="send_type_[% nr %]" class="w-full" onchange="cron_change_date(this.id)"[% IF !can_edit %] disabled[% END %]>
       <option value="month"[% IF cr.type == 'month' %] selected[% END %]>monthly</option>

--- a/templates/_cron_edit.tt
+++ b/templates/_cron_edit.tt
@@ -1,4 +1,4 @@
-﻿<tr id="send_pane_[% nr %]"[% IF nr == 0 %] style="display:none"[% END %]>
+<tr id="send_pane_[% nr %]"[% IF nr == 0 %] style="display:none"[% END %]>
   <td>
     <select name="send_type_[% nr %]" id="send_type_[% nr %]" class="w-full" onchange="cron_change_date(this.id)"[% IF !can_edit %] disabled[% END %]>
       <option value="month"[% IF cr.type == 'month' %] selected[% END %]>monthly</option>
@@ -8,7 +8,7 @@
       <option value="cust"[% IF cr.type == 'cust' %] selected[% END %]>custom</option>
     </select>
   </td>
-  <td>
+  <td[% IF show_schedule_tz %] style="white-space: normal;"[% END %]>
     <div id="div_send_month_[% nr %]">
       on day
       <select name="send_day_[% nr %]"[% IF !can_edit %] disabled[% END %]>
@@ -70,21 +70,24 @@
       <input type="text" name="send_cust_[% nr %]" value="[% IF cr.exists('cust'); escape_html(cr.cust); END %]" class="w-full" placeholder="minute hour dom month dow   (cron syntax)"[% IF !can_edit %] disabled[% END %]>
     </div>
   </td>
-  <td id="hour_select_[% nr %]">
+  <td id="hour_select_[% nr %]" class="whitespace-nowrap">
     at
-    <select name="send_hour_[% nr %]"[% IF !can_edit %] disabled[% END %]>
+    <select name="send_hour_[% nr %]" id="send_hour_[% nr %]"[% IF !can_edit %] disabled[% END %]>
       [% hour = 0 %]
       [% WHILE hour < 24 %]
       <option value="[% hour %]"[% IF cr.hour == hour %] selected[% END %]>[% sprintf("%02s", hour) %]</option>
       [% hour = hour + 1 %]
       [% END %]
-    </select>:<select name="send_minute_[% nr %]"[% IF !can_edit %] disabled[% END %]>
+    </select>:<select name="send_minute_[% nr %]" id="send_minute_[% nr %]"[% IF !can_edit %] disabled[% END %]>
       [% min = 0 %]
       [% WHILE min < 60 %]
       <option value="[% min %]"[% IF cr.minute == min %] selected[% END %]>[% sprintf("%02s", min) %]</option>
       [% min = min + 1 %]
       [% END %]
     </select>
+    [% IF show_schedule_tz %]
+    <span class="text-sm ml-1 opacity-80" id="cron_tz_suffix_[% nr %]">[% c.config._server_timezone | html %]</span>
+    [% END %]
   </td>
   <td [% IF can_edit %]class='hoverable clickable w-5 px-1 rounded' onclick="delete_cron_row(this); return false;"[% END %]>
     [% IF can_edit %]<i class="uil uil-times"></i>[% END %]
@@ -95,3 +98,11 @@
     </script>
   </td>
 </tr>
+[% IF show_schedule_tz %]
+<tr id="send_pane_preview_[% nr %]"[% IF nr == 0 %] style="display:none"[% END %]>
+  <td colspan="3" class="text-sm opacity-90" style="padding-top: 0.15rem;">
+    <div id="cron_tz_preview_[% nr %]" role="note"></div>
+  </td>
+  <td></td>
+</tr>
+[% END %]

--- a/templates/_cron_edit.tt
+++ b/templates/_cron_edit.tt
@@ -101,7 +101,7 @@
 [% IF show_schedule_tz %]
 <tr id="send_pane_preview_[% nr %]"[% IF nr == 0 %] style="display:none"[% END %]>
   <td colspan="3" class="text-sm opacity-90" style="padding-top: 0.15rem;">
-    <div id="cron_tz_preview_[% nr %]" role="note"></div>
+    <div id="cron_tz_preview_[% nr %]"></div>
   </td>
   <td></td>
 </tr>

--- a/templates/_cron_schedule_tz_header.tt
+++ b/templates/_cron_schedule_tz_header.tt
@@ -1,0 +1,10 @@
+[%# Schedule TZ notice — cron runs in _server_timezone, not browser local time %]
+<div class="text-sm mb-1 space-y-0.5" id="cron_schedule_tz_info" role="note">
+  <div class="whitespace-nowrap">
+    <i class="uil uil-info-circle"></i>
+    Schedule runs in server timezone (<strong>[% c.config._server_timezone | html %]</strong>) &mdash; cron time, not your browser clock.
+  </div>
+  <div class="pl-5 text-textlight" id="cron_schedule_tz_dayhint" style="display: none;">
+    Weekdays follow the server calendar; near midnight the day may differ in your browser.
+  </div>
+</div>

--- a/templates/_cron_schedule_tz_header.tt
+++ b/templates/_cron_schedule_tz_header.tt
@@ -1,4 +1,4 @@
-[%# Schedule TZ notice — cron runs in _server_timezone, not browser local time %]
+﻿[%# Schedule TZ notice — cron runs in _server_timezone, not browser local time %]
 <div class="text-sm mb-1 space-y-0.5" id="cron_schedule_tz_info" role="note">
   <div class="whitespace-nowrap">
     <i class="uil uil-info-circle"></i>

--- a/templates/_cron_schedule_tz_header.tt
+++ b/templates/_cron_schedule_tz_header.tt
@@ -1,5 +1,5 @@
 ﻿[%# Schedule TZ notice — cron runs in _server_timezone, not browser local time %]
-<div class="text-sm mb-1 space-y-0.5" id="cron_schedule_tz_info" role="note">
+<div class="text-sm mb-1 space-y-0.5" id="cron_schedule_tz_info">
   <div class="whitespace-nowrap">
     <i class="uil uil-info-circle"></i>
     Schedule runs in server timezone (<strong>[% c.config._server_timezone | html %]</strong>) &mdash; cron time, not your browser clock.

--- a/templates/extinfo_type_6_recurring_edit.tt
+++ b/templates/extinfo_type_6_recurring_edit.tt
@@ -5,7 +5,7 @@
 <div class="flexrow 2xl:justify-between">
   [% PROCESS _infobox.tt %]
 
-  <form action="extinfo.cgi" method="POST" class="min-w-[420px] max-w-[550px] w-full">
+  <form action="extinfo.cgi" method="POST" class="min-w-[420px] w-max max-w-full">
     <div class="card w-full">
       <input type="submit" name="send" value="save" style="display:none"><!-- make enter submit the form -->
       <input type="hidden" name="nr" value="[% rd.file | html %]">
@@ -125,12 +125,13 @@
           <tr>
             <th class="align-top">Schedule</th>
             <td colspan=2>
-              <table id="cron_entries">
+              [% PROCESS _cron_schedule_tz_header.tt %]
+              <table id="cron_entries" data-show-schedule-tz="1" data-cron-tz="[% c.config._server_timezone | html %]">
                 [% cr = { type => 'month', day => 1, week_day => '', hour => 0, minute => 0, cust => '' } %]
-                [% PROCESS _cron_edit.tt nr = 0 %]
+                [% PROCESS _cron_edit.tt nr = 0 show_schedule_tz = 1 can_edit = can_edit %]
                 [% FOREACH cr = rd.schedule %]
                     [% nr = loop.index + 1 %]
-                    [% PROCESS _cron_edit.tt %]
+                    [% PROCESS _cron_edit.tt show_schedule_tz = 1 can_edit = can_edit %]
                 [% END %]
                 [% IF can_edit %]
                   <tr>
@@ -189,12 +190,11 @@
 </div>
 
 <script>
-  <!--
-    [%+ IF rd.schedule.size == 0 +%]
-    add_cron_row('cron_entries');
-    [%+ END +%]
-    update_recurring_type_select('type_select');
-  -->
-  </script>
+  [%+ IF rd.schedule.size == 0 +%]
+  add_cron_row('cron_entries');
+  [%+ END +%]
+  init_cron_schedule_tz();
+  update_recurring_type_select('type_select');
+</script>
 
 [% PROCESS _footer.tt %]


### PR DESCRIPTION
## Summary
- Label schedule times with the server timezone and note that cron uses server time, not the browser clock.
- Show a live browser-equivalence preview for HH:MM.
- When the schedule is not daily, hint that weekdays follow the server calendar (day can differ near midnight).

Applies to recurring downtimes and reports2 schedules (shared `_cron_edit.tt`).