### PR TITLE
conf: output a proper error when boolean object values are invalid

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,6 +9,8 @@ next:
           - fix recurring downtimes added multiple times if some backends were down
           - add service time hint when editing crontab based schedules
           - fix search inputs loosing value when hitting enter
+          - Config Tool:
+            - report invalid boolean object attributes instead of a perl warning
           - Teams:
             - fix authentication by unexposed custom variables
           - Agents:

--- a/MANIFEST
+++ b/MANIFEST
@@ -2417,6 +2417,7 @@ t/014-Thruk-Utils-Crypt.t
 t/015-Thruk-Utils-APIKeys.t
 t/016-Thruk-Utils-Date.t
 t/017-Thruk-Utils-UserAgent.t
+t/018-Monitoring-Config-Object.t
 t/020-Log-Log4perl.t
 t/021-Log-Log4perl-Forks.t
 t/022-Thruk-Utils-Log.t

--- a/plugins/plugins-available/agents/lib/Thruk/Utils/Agents.pm
+++ b/plugins/plugins-available/agents/lib/Thruk/Utils/Agents.pm
@@ -784,7 +784,7 @@ sub remove_orphaned_agent_templates {
     for my $hst (@{$result}) {
         next unless $hst->{'type'} eq 'host';
         next unless defined $hst->{'obj'}->{'conf'}->{'register'};
-        next unless $hst->{'obj'}->{'conf'}->{'register'} == 0;
+        next unless $hst->{'obj'}->{'conf'}->{'register'} eq '0';
         next unless $hst->{'obj'}->{'conf'}->{'name'} =~ m/^agent\-/mx;
         $c->{'obj_db'}->delete_object($hst->{'obj'});
     }

--- a/plugins/plugins-available/conf/lib/Monitoring/Config.pm
+++ b/plugins/plugins-available/conf/lib/Monitoring/Config.pm
@@ -2146,7 +2146,7 @@ sub _update_obj_in_index {
 
     if($found || defined $primary) {
         # by type
-        if(!defined $obj->{'conf'}->{'register'} || $obj->{'conf'}->{'register'} != 0) {
+        if(!defined $obj->{'conf'}->{'register'} || $obj->{'conf'}->{'register'} ne '0') {
             push @{$objects->{'bytype'}->{$obj->{'type'}}}, $obj->{'id'};
         }
     }

--- a/plugins/plugins-available/conf/lib/Monitoring/Config/Object/Parent.pm
+++ b/plugins/plugins-available/conf/lib/Monitoring/Config/Object/Parent.pm
@@ -70,6 +70,10 @@ sub parse {
                     $self->{'conf'}->{$attr} = [];
                 }
             }
+
+            if($field->{'type'} eq 'BOOL' and $value ne '0' and $value ne '1') {
+                push @{$parse_errors}, "invalid boolean value for $attr: '".$value."' in ".Thruk::Utils::Conf::link_obj($self);
+            }
         } elsif(substr($attr, 0, 1) eq '_') {
             $self->{'conf'}->{$attr} = $value;
         } else {
@@ -222,7 +226,7 @@ returns 1 if this is a template
 =cut
 sub is_template {
     my($self) = @_;
-    return 1 if (defined $self->{'conf'}->{'register'} and $self->{'conf'}->{'register'} == 0);
+    return 1 if (defined $self->{'conf'}->{'register'} and $self->{'conf'}->{'register'} eq '0');
     return 1 if $self->get_template_name();
     return 0;
 }
@@ -237,7 +241,7 @@ return the objects template name or undef
 sub get_template_name {
     my($self) = @_;
     # in case there is no name set, use the primary name
-    if(defined $self->{'conf'}->{'register'} && $self->{'conf'}->{'register'} == 0 && !defined $self->{'conf'}->{'name'} && defined $self->{'conf'}->{$self->{'primary_key'}}) {
+    if(defined $self->{'conf'}->{'register'} && $self->{'conf'}->{'register'} eq '0' && !defined $self->{'conf'}->{'name'} && defined $self->{'conf'}->{$self->{'primary_key'}}) {
         return $self->{'conf'}->{$self->{'primary_key'}};
     }
     return $self->{'conf'}->{'name'};
@@ -810,7 +814,7 @@ sub set_name {
     die("no new name!") unless defined $newname;
 
     my $conf = $self->{'conf'};
-    if(defined $conf->{'register'} and $conf->{'register'} == 0) {
+    if(defined $conf->{'register'} and $conf->{'register'} eq '0') {
         $conf->{'name'} = $newname;
         return;
     }

--- a/plugins/plugins-available/conf/lib/Thruk/Controller/conf.pm
+++ b/plugins/plugins-available/conf/lib/Thruk/Controller/conf.pm
@@ -1901,7 +1901,7 @@ sub _get_context_object {
                     push @newobjs, $o if $o->is_template();
                 }
                 if($templates == 2) {
-                    push @newobjs, $o if !defined $o->{'conf'}->{'register'} || $o->{'conf'}->{'register'} != 0;
+                    push @newobjs, $o if !defined $o->{'conf'}->{'register'} || $o->{'conf'}->{'register'} ne '0';
                 }
             }
             @{$objs} = @newobjs;

--- a/t/018-Monitoring-Config-Object.t
+++ b/t/018-Monitoring-Config-Object.t
@@ -1,0 +1,113 @@
+#!/usr/bin/env perl
+
+use warnings;
+use strict;
+use File::Temp qw/tempdir/;
+use Test::More;
+
+use lib('plugins/plugins-available/conf/lib');
+
+plan skip_all => 'internal test only' if defined $ENV{'PLACK_TEST_EXTERNALSERVER_URI'};
+
+use_ok('Monitoring::Config::File') or BAIL_OUT($@);
+
+my $tmpdir = tempdir(CLEANUP => 1);
+my $nr     = 0;
+
+# a misconfigured boolean must be reported as a parse error, never as a perl
+# warning, so any warning raised while parsing fails the test
+my @warnings;
+$SIG{__WARN__} = sub { push @warnings, $_[0] };
+
+##########################################################
+# writes the given object config and returns the parsed file
+sub _parse {
+    my($text) = @_;
+    my $path  = $tmpdir.'/test'.($nr++).'.cfg';
+    open(my $fh, '>', $path) or die("cannot write $path: $!");
+    print $fh $text;
+    close($fh);
+    @warnings = ();
+    my $file = Monitoring::Config::File->new($path, [], 'nagios');
+    $file->update_objects();
+    return($file);
+}
+
+##########################################################
+# returns the parsed file for a host object with the given register line
+sub _parse_register {
+    my($value) = @_;
+    my $line = defined $value ? 'register       '.$value : 'register';
+    return(_parse("define host {\n  host_name      testhost\n  ".$line."\n}\n"));
+}
+
+##########################################################
+# only 0 and 1 are valid, everything else is reported and treated as a
+# regular object
+my $cases = [
+    # register value  errors  is_template  description
+    [ '0',            0,      1,           'valid template marker' ],
+    [ '1',            0,      0,           'valid registered object' ],
+    [ '0v',           1,      0,           'trailing character typo' ],
+    [ 'foo',          1,      0,           'non numeric value' ],
+    [ 'yes',          1,      0,           'boolean like word' ],
+    [ '00',           1,      0,           'numerically zero but written differently' ],
+    [ '0.0',          1,      0,           'numerically zero as float' ],
+    [ '-0',           1,      0,           'numerically zero with sign' ],
+    [ undef,          1,      0,           'attribute without any value' ],
+];
+
+for my $case (@{$cases}) {
+    my($value, $exp_errors, $exp_template, $descr) = @{$case};
+    my $file = _parse_register($value);
+    is(scalar @{$file->{'parse_errors'}}, $exp_errors, $descr.': number of parse errors')
+        or diag(join("\n", @{$file->{'parse_errors'}}));
+    my $obj = $file->{'objects'}->[0];
+    isa_ok($obj, 'Monitoring::Config::Object::Host', $descr.': object parsed');
+    is($obj->is_template(), $exp_template, $descr.': is_template');
+    # checked last on purpose, so it covers evaluating the value as well as
+    # parsing it. a numeric comparison anywhere would show up here.
+    is(scalar @warnings, 0, $descr.': raised no perl warnings')
+        or diag(join("\n", @warnings));
+}
+
+##########################################################
+# the error names the attribute and the offending value
+my $file = _parse_register('0v');
+like($file->{'parse_errors'}->[0], qr/invalid\ boolean\ value\ for\ register/mx, 'error names the attribute');
+like($file->{'parse_errors'}->[0], qr/'0v'/mx,                                   'error contains the offending value');
+
+##########################################################
+# the invalid value is reported, not repaired: it must survive parsing
+# untouched so it stays in the file on disk
+my $obj = $file->{'objects'}->[0];
+ok(exists $obj->{'conf'}->{'register'}, 'invalid attribute has not been removed');
+is($obj->{'conf'}->{'register'}, '0v',  'invalid value is unchanged');
+
+##########################################################
+# every place which inspects register must agree, an invalid value is not a
+# template anywhere
+is($obj->is_template(), 0,             'invalid value is not a template');
+is($obj->get_primary_name(), 'testhost', 'invalid value keeps its primary name');
+is($obj->get_template_name(), undef,   'invalid value has no template name');
+is(scalar @warnings, 0, 'inspecting an invalid value raises no perl warnings')
+    or diag(join("\n", @warnings));
+
+##########################################################
+# validation is not specific to register
+$file = _parse("define host {\n  host_name      testhost\n  active_checks_enabled  maybe\n}\n");
+is(scalar @{$file->{'parse_errors'}}, 1, 'other boolean attributes are validated too')
+    or diag(join("\n", @{$file->{'parse_errors'}}));
+is(scalar @warnings, 0, 'other boolean attributes raise no perl warnings')
+    or diag(join("\n", @warnings));
+like($file->{'parse_errors'}->[0], qr/invalid\ boolean\ value\ for\ active_checks_enabled/mx, 'error names the attribute');
+
+##########################################################
+# disabled objects stay exempt from parse errors
+$file = _parse("#define host {\n#  host_name      testhost\n#  register       0v\n#}\n");
+is(scalar @{$file->{'parse_errors'}}, 0, 'disabled objects report no parse errors')
+    or diag(join("\n", @{$file->{'parse_errors'}}));
+is(scalar @warnings, 0, 'disabled objects raise no perl warnings')
+    or diag(join("\n", @warnings));
+
+done_testing();


### PR DESCRIPTION
perl evaluates "0v" == 0 as true, so a typo in register silently turned the object into a template and it vanished from the object list, leaving only a numeric warning in the log.