### PR TITLE
ai commit: detect empty quick search queries and redirect them to status.cgi?style=detail

### DIFF
--- a/lib/Thruk/Utils/Status.pm
+++ b/lib/Thruk/Utils/Status.pm
@@ -3353,6 +3353,19 @@ sub try_host_only_filter {
     return unless ($params->{'s0_op'}   && $params->{'s0_op'}   eq '~');      # full text regex filter
     return if     defined $params->{'s1_type'}; # there is only one search
 
+    if(    $params->{'quicksearch'}
+       and defined $params->{'s0_value'}
+       and $params->{'s0_value'} eq ''
+    ) {
+        return Thruk::Utils::Filter::uri_with($c, {
+            's0_op'                       => undef,
+            's0_type'                     => undef,
+            's0_value'                    => undef,
+            'add_default_service_filter'  => undef,
+            'quicksearch'                 => undef,
+        }, 1);
+    }
+
     my $name = $params->{'s0_value'};
     if(!Thruk::Utils::is_valid_regular_expression(undef, $name)) {
         return;

--- a/templates/_header.tt
+++ b/templates/_header.tt
@@ -55,6 +55,7 @@
                     <input type='hidden' name='s0_op' value='~' />
                     <input type='hidden' name='s0_type' value='search' />
                     <input type='hidden' name='add_default_service_filter' value='1' />
+                    <input type='hidden' name='quicksearch' value='1' />
                     <input type='search' name='s0_value' class="deletable autosubmit headersearch js-autoexpand js-suggest-advanced" id="header-search" placeholder="search..." />
                     <input type='search' name='q' onfocus="initAutoCompleteQuery(this, queryCodeCompletions)" class="w-48 js-advancedfilter" placeholder="advanced search..." autocomplete="off" style="display: none;" disabled />
                   </fieldset>

--- a/templates/side.tt
+++ b/templates/side.tt
@@ -51,6 +51,7 @@
                         <input type='hidden' name='s0_op' value='~' id="s0_to" />
                         <input type='hidden' name='s0_type' value='search' />
                         <input type='hidden' name='add_default_service_filter' value='1' />
+                        <input type='hidden' name='quicksearch' value='1' />
                         <input type='search' name='s0_value' class="deletable autosubmit js-suggest-advanced w-full my-[1px]" id="s0_value" placeholder="search..." />
                         <input type='search' name='q' onfocus="initAutoCompleteQuery(this, queryCodeCompletions)" class="w-full js-advancedfilter" placeholder="advanced search..." autocomplete="off" style="display: none;" disabled />
                       </fieldset>


### PR DESCRIPTION
add a hidden quicksearch input to the form that is sent when user does a quicksearch. if the s0_value is empty string, and quciksearch parameter is there, one can do a clean redirect to the service details page

just looking at s0_value would not be enough as it can be manually set to something, or change meaning if operator is !~ etc. . The quicksearch input solidifies the fact that the request came from intended target of quicksearch box.

the search parameters are stripped, only the status.cgi?style=hostdetail remains.