### PR TITLE
ai commit: add limits to the status.cgi style=combined table

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -2503,6 +2503,7 @@ t/300-controller_rest_v1.t
 t/300-controller_Root.t
 t/300-controller_showlog.t
 t/300-controller_status.t
+t/300-controller_status_combined.t
 t/300-controller_summary.t
 t/300-controller_tac.t
 t/300-controller_test.t

--- a/lib/Thruk/Backend/Provider/Livestatus.pm
+++ b/lib/Thruk/Backend/Provider/Livestatus.pm
@@ -642,6 +642,8 @@ sub get_services {
     my($self, %options) = @_;
     return($options{'data'}) if($options{'data'});
 
+    my $explicit_limit = $options{'options'}->{'limit'};
+
     # optimized naemon with wrapped_json output
     if($self->{'lmd_optimizations'} || $self->{'naemon_optimizations'}) {
         $self->_optimized_for_wrapped_json(\%options, "services");
@@ -703,7 +705,7 @@ sub get_services {
         if(ref $filter eq 'HASH') {
             my @keys = keys %{$filter};
             if(scalar @keys == 1 && $keys[0] eq 'host_name') {
-                delete $options{'options'}->{'limit'};
+                delete $options{'options'}->{'limit'} unless $explicit_limit;
             }
         }
         $options{'filter'} = [$filter];

--- a/lib/Thruk/Controller/rest_v1.pm
+++ b/lib/Thruk/Controller/rest_v1.pm
@@ -534,7 +534,7 @@ sub _fetch {
             if($request_method ne 'GET' && !Thruk::Utils::check_csrf($c, 1)) {
                 # make csrf protection mandatory for anything other than GET requests
                 return({
-                    'message'     => 'invalid or no csfr token',
+                    'message'     => 'invalid or no csrf token',
                     'code'        => 403,
                     'failed'      => Cpanel::JSON::XS::true,
                 });

--- a/lib/Thruk/Controller/status.pm
+++ b/lib/Thruk/Controller/status.pm
@@ -3,6 +3,7 @@ package Thruk::Controller::status;
 use warnings;
 use strict;
 use Cpanel::JSON::XS qw/decode_json/;
+use URI ();
 
 use Thruk::Action::AddDefaults ();
 use Thruk::Backend::Manager ();
@@ -1219,6 +1220,9 @@ sub _process_combined_page {
     my(undef, $servicefilter) = Thruk::Utils::Status::do_filter($c, 'svc_');
     return 1 if $c->stash->{'has_error'};
 
+    my $problems_limit = $c->config->{'problems_limit'};
+    my $limit          = ($view_mode eq 'html' && $problems_limit) ? $problems_limit + 1 : undef;
+
     # services
     my $sorttype   = $c->req->parameters->{'sorttype_svc'}   || 1;
     my $sortoption = $c->req->parameters->{'sortoption_svc'} || 1;
@@ -1252,6 +1256,9 @@ sub _process_combined_page {
     $c->stash->{'svc_orderby'}  = $sortoptions->{$sortoption}->[1];
     $c->stash->{'svc_orderdir'} = $order;
 
+    my $backend_order = $order;
+    if($sortoption eq "6") { $backend_order = $order eq 'ASC' ? 'DESC' : 'ASC'; }
+
     my $extra_svc_columns = [];
     my $extra_hst_columns = [];
     if($c->config->{'use_lmd_core'} && $c->stash->{'show_long_plugin_output'} ne 'inline' && $view_mode eq 'html') {
@@ -1264,11 +1271,11 @@ sub _process_combined_page {
     push @{$extra_svc_columns}, 'contacts' if ( grep ( /^contacts$/ixm , @{Thruk::Base::list($selected_svc_columns)} ) );
 
     my $services = $c->db->get_services( filter => [ Thruk::Utils::Auth::get_auth_filter( $c, 'services' ), $servicefilter ],
-                                         sort   => { $order => $sortoptions->{$sortoption}->[0] },
+                                         sort   => { $backend_order => $sortoptions->{$sortoption}->[0] },
                                          extra_columns => $extra_svc_columns,
+                                         ($limit && !$c->req->parameters->{'show_all_services'} ? (limit => $limit) : ()),
                                        );
     $c->stash->{'services'} = $services;
-    if( $sortoption eq "6" and defined $services ) { @{ $c->stash->{'services'} } = reverse @{ $c->stash->{'services'} }; }
 
 
     # hosts
@@ -1303,12 +1310,15 @@ sub _process_combined_page {
     $c->stash->{'hst_orderdir'} = $order;
     push @{$extra_hst_columns}, 'contacts' if ( grep ( /^contacts$/ixm , @{Thruk::Base::list($selected_hst_columns)} ) );
 
+    $backend_order = $order;
+    if($sortoption == 6) { $backend_order = $order eq 'ASC' ? 'DESC' : 'ASC'; }
+
     my $hosts = $c->db->get_hosts( filter => [ Thruk::Utils::Auth::get_auth_filter( $c, 'hosts' ), $hostfilter ],
-                                   sort   => { $order => $sortoptions->{$sortoption}->[0] },
+                                   sort   => { $backend_order => $sortoptions->{$sortoption}->[0] },
                                    extra_columns => $extra_hst_columns,
+                                   ($limit && !$c->req->parameters->{'show_all_hosts'} ? (limit => $limit) : ()),
                                  );
     $c->stash->{'hosts'} = $hosts;
-    if( $sortoption == 6 and defined $hosts ) { @{ $c->stash->{'hosts'} } = reverse @{ $c->stash->{'hosts'} }; }
 
     $c->stash->{'hosts_limit_hit'}    = 0;
     $c->stash->{'services_limit_hit'} = 0;
@@ -1341,15 +1351,18 @@ sub _process_combined_page {
         };
         return $c->render(json => $json);
     } else {
-        if($c->config->{problems_limit}) {
-            if(scalar @{$c->stash->{'hosts'}} > $c->config->{problems_limit} && !$c->req->parameters->{'show_all_hosts'}) {
+        if($problems_limit) {
+            if(scalar @{$c->stash->{'hosts'}} > $problems_limit && !$c->req->parameters->{'show_all_hosts'}) {
                 $c->stash->{'hosts_limit_hit'}    = 1;
-                $c->stash->{'hosts'}              = [splice(@{$c->stash->{'hosts'}}, 0, $c->config->{problems_limit})];
+                $c->stash->{'hosts'}              = [splice(@{$c->stash->{'hosts'}}, 0, $problems_limit)];
             }
-            if(scalar @{$c->stash->{'services'}} > $c->config->{problems_limit} && !$c->req->parameters->{'show_all_services'}) {
+            if(scalar @{$c->stash->{'services'}} > $problems_limit && !$c->req->parameters->{'show_all_services'}) {
                 $c->stash->{'services_limit_hit'} = 1;
-                $c->stash->{'services'}           = [splice(@{$c->stash->{'services'}}, 0, $c->config->{problems_limit})];
+                $c->stash->{'services'}           = [splice(@{$c->stash->{'services'}}, 0, $problems_limit)];
             }
+            # point to the paginated detail tables instead of rendering all rows here
+            $c->stash->{'hosts_show_all_url'}    = _combined_show_all_url($c, 'hst_', 'hostdetail') if $c->stash->{'hosts_limit_hit'};
+            $c->stash->{'services_show_all_url'} = _combined_show_all_url($c, 'svc_', 'detail')    if $c->stash->{'services_limit_hit'};
         }
     }
 
@@ -1357,6 +1370,43 @@ sub _process_combined_page {
     Thruk::Utils::Status::set_audio_file($c);
 
     return 1;
+}
+
+##########################################################
+# create a 'show all' url for a limited table on the combined page.
+# The combined page uses its own filter prefixes (hst_/svc_) while the paginated hostdetail/detail pages use the dfl_ prefix
+sub _combined_show_all_url {
+    my($c, $from_prefix, $to_style) = @_;
+
+    my $uri     = URI->new('status.cgi');
+    my @new_param;
+    my $base    = $c->stash->{'original_uri'} ? URI->new($c->stash->{'original_uri'}) : $c->req->uri;
+    my @old_param = $base->query_form();
+    while(my $key = shift @old_param) {
+        my $value = shift @old_param;
+        next if $key eq '_';
+        next if $key eq 'style';
+        next if $key =~ m/^show_all_(hosts|services)$/mx;
+        next if $key =~ m/^(sorttype|sortoption)(_hst|_svc)?$/mx;
+        next if $key eq 'entries' || $key eq 'page' || $key eq 'jump';
+        # translate column params of this table, drop column params of the other one
+        if($from_prefix eq 'hst_') {
+            next if $key eq 'service_columns';
+            $key = 'dfl_columns' if $key eq 'host_columns';
+        } else {
+            next if $key eq 'host_columns';
+            $key = 'dfl_columns' if $key eq 'service_columns';
+        }
+        # drop filters which belong to the other tables
+        next if $key =~ m/^(?:hst|svc|dfl|ovr|grd)_/mx && $key !~ m/^\Q$from_prefix\E/mx;
+        # switch table filters to the prefix used by the target pages
+        $key =~ s/^\Q$from_prefix\E/dfl_/mx if $key =~ m/^\Q$from_prefix\E/mx;
+        next if !defined $value || $value eq '';
+        push @new_param, $key, $value;
+    }
+    push @new_param, 'style', $to_style;
+    $uri->query_form(@new_param);
+    return($uri->as_string());
 }
 
 ##########################################################

--- a/lib/Thruk/Controller/status.pm
+++ b/lib/Thruk/Controller/status.pm
@@ -3,7 +3,6 @@ package Thruk::Controller::status;
 use warnings;
 use strict;
 use Cpanel::JSON::XS qw/decode_json/;
-use URI ();
 
 use Thruk::Action::AddDefaults ();
 use Thruk::Backend::Manager ();

--- a/t/300-controller_status_combined.t
+++ b/t/300-controller_status_combined.t
@@ -11,7 +11,6 @@ BEGIN {
     import TestUtils;
 }
 
-# lower the problems limit, so we can hit it with the test site
 my $res = TestUtils::request('/thruk/cgi-bin/status.cgi?style=combined');
 plan skip_all => 'no working backend' if !$res->is_success;
 my $old_limit = Thruk->config->{'problems_limit'};
@@ -22,132 +21,106 @@ my $all_problems = '/thruk/cgi-bin/status.cgi?style=combined'
                  . '&hst_s0_hoststatustypes=15&hst_s0_servicestatustypes=31&hst_s0_hostprops=0&hst_s0_serviceprops=0'
                  . '&svc_s0_hoststatustypes=15&svc_s0_servicestatustypes=31&svc_s0_hostprops=0&svc_s0_serviceprops=0';
 
-# --------------------------------------------------------------------------
-# The html view fetches only problems_limit + 1 rows, so the following checks
-# are cheap even on big sites: only one small (limited) query per table.
-# --------------------------------------------------------------------------
 $res = TestUtils::request($all_problems);
 plan skip_all => 'no working backend' if !$res->is_success;
+
+plan tests => 40;
+
 my $content = $res->decoded_content || $res->content;
-my $hosts_big    = $content =~ m{Limit of $problems_limit matching hosts reached};
-my $services_big = $content =~ m{Limit of $problems_limit matching services reached};
-plan skip_all => 'test site too small for combined limit tests' if(!$hosts_big || !$services_big);
-plan tests => 41;
 
 unlike($content, qr/show_all_hosts/,     'no more show_all_hosts link');
 unlike($content, qr/show_all_services/,  'no more show_all_services link');
 like($content, qr/Host and Service Details/m, 'combined page shows its heading');
 
-# build/show the links and verify the filters are converted to the dfl_ prefix
-if($hosts_big) {
-    ok(1, 'hosts table hit the problems limit');
-    my($href) = $content =~ m{<a href="([^"]*)"[^>]*><span class="textALERT">Limit of $problems_limit matching hosts reached};
-    ok($href, 'found show all hosts link to hostdetail page');
-    if($href) {
-        like($href, qr/status\.cgi\?[^"]*style=hostdetail/mx,   'hosts link points to hostdetail');
-        like($href, qr/dfl_s0_hoststatustypes=15/mx,             'hosts link keeps host filters with dfl_ prefix');
-        like($href, qr/dfl_s0_servicestatustypes=31/mx,          'hosts link keeps host filters with dfl_ prefix');
-        like($href, qr/dfl_s0_hostprops=0/mx,                    'hosts link keeps host properties with dfl_ prefix');
-        like($href, qr/dfl_s0_serviceprops=0/mx,                 'hosts link keeps service properties with dfl_ prefix');
-        unlike($href, qr/(?:^|[?&])svc_/mx,                      'hosts link drops service filters');
-        unlike($href, qr/(?:^|[?&])hst_s0_/mx,                   'hosts link has no hst_ prefixed filters anymore');
+my($href_hosts) = $content =~ m{<a href="([^"]*)"[^>]*><span class="textALERT">Limit of $problems_limit matching hosts reached};
+ok($href_hosts, 'found show all hosts link to hostdetail page');
+if($href_hosts) {
+    like($href_hosts, qr/status\.cgi\?[^"]*style=hostdetail/mx,   'hosts link points to hostdetail');
+    like($href_hosts, qr/dfl_s0_hoststatustypes=15/mx,             'hosts link keeps host filters with dfl_ prefix');
+    like($href_hosts, qr/dfl_s0_servicestatustypes=31/mx,          'hosts link keeps host filters with dfl_ prefix');
+    like($href_hosts, qr/dfl_s0_hostprops=0/mx,                    'hosts link keeps host properties with dfl_ prefix');
+    like($href_hosts, qr/dfl_s0_serviceprops=0/mx,                 'hosts link keeps service properties with dfl_ prefix');
+    unlike($href_hosts, qr/(?:^|[?&])svc_/mx,                      'hosts link drops service filters');
+    unlike($href_hosts, qr/(?:^|[?&])hst_s0_/mx,                   'hosts link has no hst_ prefixed filters anymore');
 
-        $href =~ s/&amp;/&/gmx;
-        $href = '/thruk/cgi-bin/'.$href if $href =~ m{^status\.cgi\?};
-        my $page_res = TestUtils::request($href);
-        ok($page_res->is_success, 'hostdetail page should succeed');
-        my $page_content = $page_res->decoded_content || $page_res->content;
-        my($total) = $page_content =~ m{of (\d+) Items Displayed};
-        like($page_content, qr/Current Network Status/m, 'hostdetail page renders');
-        like($page_content, qr/of \d+ Items Displayed/m, 'hostdetail page is paginated');
-        like($page_content, qr/dfl_s0_hoststatustypes/mx, 'hostdetail page kept the filters');
-        ok(defined $total && $total > $problems_limit, 'hostdetail page shows more than problems_limit hosts');
-        SKIP: {
-            skip 'fewer than one page of hosts', 1 if !defined $total || $total <= 100;
-            like($page_content, qr/page=2/mx, 'hostdetail page has a second page');
-        }
-        unlike($page_content, qr/Limit of $problems_limit matching hosts reached/m, 'hostdetail page is not limited by problems_limit');
+    $href_hosts =~ s/&amp;/&/gmx;
+    $href_hosts = '/thruk/cgi-bin/'.$href_hosts if $href_hosts =~ m{^status\.cgi\?};
+    my $page_res = TestUtils::request($href_hosts);
+    ok($page_res->is_success, 'hostdetail page should succeed');
+
+    my $page_content = $page_res->decoded_content || $page_res->content;
+    my($total) = $page_content =~ m{of (\d+) Items Displayed};
+
+    like($page_content, qr/Current Network Status/m, 'hostdetail page renders');
+    like($page_content, qr/of \d+ Items Displayed/m, 'hostdetail page is paginated');
+    like($page_content, qr/dfl_s0_hoststatustypes/mx, 'hostdetail page kept the filters');
+    ok(defined $total && $total > $problems_limit, 'hostdetail page shows more than problems_limit hosts');
+
+    SKIP: {
+        skip 'fewer than one page of hosts', 1 if !defined $total || $total <= 100;
+        like($page_content, qr/page=2/mx, 'hostdetail page has a second page');
     }
-} else {
-    ok(1, 'hosts table below problems limit, skipping host link tests');
+    unlike($page_content, qr/Limit of $problems_limit matching hosts reached/m, 'hostdetail page is not limited by problems_limit');
 }
 
-if($services_big) {
-    ok(1, 'services table hit the problems limit');
-    my($href) = $content =~ m{<a href="([^"]*)"[^>]*><span class="alerttext">Limit of $problems_limit matching services reached};
-    ok($href, 'found show all services link to detail page');
-    if($href) {
-        like($href, qr/status\.cgi\?[^"]*style=detail/mx,   'services link points to detail');
-        like($href, qr/dfl_s0_hoststatustypes=15/mx,         'services link keeps service filters with dfl_ prefix');
-        like($href, qr/dfl_s0_servicestatustypes=31/mx,      'services link keeps service filters with dfl_ prefix');
-        like($href, qr/dfl_s0_hostprops=0/mx,                'services link keeps host properties with dfl_ prefix');
-        like($href, qr/dfl_s0_serviceprops=0/mx,             'services link keeps service properties with dfl_ prefix');
-        unlike($href, qr/(?:^|[?&])hst_/mx,                  'services link drops host filters');
-        unlike($href, qr/(?:^|[?&])svc_s0_/mx,               'services link has no svc_ prefixed filters anymore');
+ok(1, 'services table hit the problems limit');
+my($href_services) = $content =~ m{<a href="([^"]*)"[^>]*><span class="alerttext">Limit of $problems_limit matching services reached};
+ok($href_services, 'found show all services link to detail page');
+if($href_services) {
+    like($href_services, qr/status\.cgi\?[^"]*style=detail/mx,   'services link points to detail');
+    like($href_services, qr/dfl_s0_hoststatustypes=15/mx,         'services link keeps service filters with dfl_ prefix');
+    like($href_services, qr/dfl_s0_servicestatustypes=31/mx,      'services link keeps service filters with dfl_ prefix');
+    like($href_services, qr/dfl_s0_hostprops=0/mx,                'services link keeps host properties with dfl_ prefix');
+    like($href_services, qr/dfl_s0_serviceprops=0/mx,             'services link keeps service properties with dfl_ prefix');
+    unlike($href_services, qr/(?:^|[?&])hst_/mx,                  'services link drops host filters');
+    unlike($href_services, qr/(?:^|[?&])svc_s0_/mx,               'services link has no svc_ prefixed filters anymore');
 
-        $href =~ s/&amp;/&/gmx;
-        $href = '/thruk/cgi-bin/'.$href if $href =~ m{^status\.cgi\?};
-        my $page_res = TestUtils::request($href);
-        ok($page_res->is_success, 'detail page should succeed');
-        my $page_content = $page_res->decoded_content || $page_res->content;
-        my($total) = $page_content =~ m{of (\d+) Items Displayed};
-        like($page_content, qr/Current Network Status/m, 'detail page renders');
-        like($page_content, qr/of \d+ Items Displayed/m, 'detail page is paginated');
-        like($page_content, qr/dfl_s0_hoststatustypes/mx, 'detail page kept the filters');
-        ok(defined $total && $total > $problems_limit, 'detail page shows more than problems_limit services');
-        SKIP: {
-            skip 'fewer than one page of services', 1 if !defined $total || $total <= 100;
-            like($page_content, qr/page=2/mx, 'detail page has a second page');
-        }
-        unlike($page_content, qr/Limit of $problems_limit matching services reached/m, 'detail page is not limited by problems_limit');
+    $href_services =~ s/&amp;/&/gmx;
+    $href_services = '/thruk/cgi-bin/'.$href_services if $href_services =~ m{^status\.cgi\?};
+    my $page_res = TestUtils::request($href_services);
+    ok($page_res->is_success, 'detail page should succeed');
+
+    my $page_content = $page_res->decoded_content || $page_res->content;
+    my($total) = $page_content =~ m{of (\d+) Items Displayed};
+
+    like($page_content, qr/Current Network Status/m, 'detail page renders');
+    like($page_content, qr/of \d+ Items Displayed/m, 'detail page is paginated');
+    like($page_content, qr/dfl_s0_hoststatustypes/mx, 'detail page kept the filters');
+    ok(defined $total && $total > $problems_limit, 'detail page shows more than problems_limit services');
+
+    SKIP: {
+        skip 'fewer than one page of services', 1 if !defined $total || $total <= 100;
+        like($page_content, qr/page=2/mx, 'detail page has a second page');
     }
-} else {
-    ok(1, 'services table below problems limit, skipping service link tests');
+    unlike($page_content, qr/Limit of $problems_limit matching services reached/m, 'detail page is not limited by problems_limit');
 }
 
-# --------------------------------------------------------------------------
-# sortoption 6 (state duration) works together with the limit
-# --------------------------------------------------------------------------
+# sortoption state duration with ID 6 works together with the limit
 $res = TestUtils::request($all_problems.'&sortoption_svc=6&sorttype_svc=1&sortoption_hst=6&sorttype_hst=1');
 ok($res->is_success, 'combined page with state duration sort should succeed');
 my $duration_content = $res->decoded_content || $res->content;
-if($hosts_big) {
-    like($duration_content, qr/Limit of $problems_limit matching hosts reached/m, 'hosts limit hit with state duration sort');
-} else {
-    unlike($duration_content, qr/Limit of $problems_limit matching hosts reached/m, 'no hosts limit with state duration sort');
-}
-if($services_big) {
-    like($duration_content, qr/Limit of $problems_limit matching services reached/m, 'services limit hit with state duration sort');
-} else {
-    unlike($duration_content, qr/Limit of $problems_limit matching services reached/m, 'no services limit with state duration sort');
-}
+like($duration_content, qr/Limit of $problems_limit matching hosts reached/m, 'hosts limit hit with state duration sort');
+like($duration_content, qr/Limit of $problems_limit matching services reached/m, 'services limit hit with state duration sort');
 
-# --------------------------------------------------------------------------
-# no limit link if the filter matches fewer objects than the problems_limit
-# --------------------------------------------------------------------------
+
+
+# no limit link if the filter matches fewer objects, exactly one, less than the current problems_limit which is two
 my $host_res = TestUtils::request('/thruk/r/hosts?columns=name&limit=1');
-if($host_res->is_success) {
-    my $hosts_json = eval { decode_json($host_res->decoded_content || $host_res->content) };
-    if(!$@ && ref $hosts_json eq 'ARRAY' && scalar @{$hosts_json} > 0) {
-        my $host_name = $hosts_json->[0]->{'name'};
-        my $single_host = '/thruk/cgi-bin/status.cgi?style=combined'
-                        . '&hst_s0_type=host&hst_s0_op=%3D&hst_s0_value='.uri_escape($host_name)
-                        . '&hst_s0_hoststatustypes=15&hst_s0_servicestatustypes=31&hst_s0_hostprops=0&hst_s0_serviceprops=0'
-                        . '&svc_s0_hoststatustypes=15&svc_s0_servicestatustypes=31&svc_s0_hostprops=0&svc_s0_serviceprops=0';
-        $res = TestUtils::request($single_host);
-        ok($res->is_success, 'single host combined page should succeed');
-        my $single_content = $res->decoded_content || $res->content;
-        like($single_content, qr/1 of 1 Matching Host Entries Displayed/m, 'single host shows 1 of 1 hosts');
-        unlike($single_content, qr/Limit of \d+ matching hosts reached/m, 'no host limit link for a single host');
-    } else {
-        ok(1, 'no test host available (1/3)');
-        ok(1, 'no test host available (2/3)');
-        ok(1, 'no test host available (3/3)');
-    }
-} else {
-    ok(1, 'no test host available (1/3)');
-    ok(1, 'no test host available (2/3)');
-    ok(1, 'no test host available (3/3)');
+
+my $hosts_json = eval { decode_json($host_res->decoded_content || $host_res->content) };
+if(!$@ && ref $hosts_json eq 'ARRAY' && scalar @{$hosts_json} > 0) {
+    my $host_name = $hosts_json->[0]->{'name'};
+    my $single_host = '/thruk/cgi-bin/status.cgi?style=combined'
+                    . '&hst_s0_type=host&hst_s0_op=%3D&hst_s0_value='.uri_escape($host_name)
+                    . '&hst_s0_hoststatustypes=15&hst_s0_servicestatustypes=31&hst_s0_hostprops=0&hst_s0_serviceprops=0'
+                    . '&svc_s0_hoststatustypes=15&svc_s0_servicestatustypes=31&svc_s0_hostprops=0&svc_s0_serviceprops=0';
+    $res = TestUtils::request($single_host);
+
+    ok($res->is_success, 'single host combined page should succeed');
+
+    my $single_content = $res->decoded_content || $res->content;
+    like($single_content, qr/1 of 1 Matching Host Entries Displayed/m, 'single host shows 1 of 1 hosts');
+    unlike($single_content, qr/Limit of \d+ matching hosts reached/m, 'no host limit link for a single host');
 }
 
 # restore the limit for potential other tests in this process

--- a/t/300-controller_status_combined.t
+++ b/t/300-controller_status_combined.t
@@ -1,0 +1,154 @@
+use warnings;
+use strict;
+use Cpanel::JSON::XS qw/decode_json/;
+use Test::More;
+use URI::Escape qw/uri_escape/;
+
+BEGIN {
+    plan skip_all => 'backends required' if(!-s ($ENV{'THRUK_CONFIG'} || '.').'/thruk_local.conf' and !defined $ENV{'PLACK_TEST_EXTERNALSERVER_URI'});
+    use lib('t');
+    require TestUtils;
+    import TestUtils;
+}
+
+# lower the problems limit, so we can hit it with the test site
+my $res = TestUtils::request('/thruk/cgi-bin/status.cgi?style=combined');
+plan skip_all => 'no working backend' if !$res->is_success;
+my $old_limit = Thruk->config->{'problems_limit'};
+my $problems_limit = 2;
+Thruk->config->{'problems_limit'} = $problems_limit;
+
+my $all_problems = '/thruk/cgi-bin/status.cgi?style=combined'
+                 . '&hst_s0_hoststatustypes=15&hst_s0_servicestatustypes=31&hst_s0_hostprops=0&hst_s0_serviceprops=0'
+                 . '&svc_s0_hoststatustypes=15&svc_s0_servicestatustypes=31&svc_s0_hostprops=0&svc_s0_serviceprops=0';
+
+# --------------------------------------------------------------------------
+# The html view fetches only problems_limit + 1 rows, so the following checks
+# are cheap even on big sites: only one small (limited) query per table.
+# --------------------------------------------------------------------------
+$res = TestUtils::request($all_problems);
+plan skip_all => 'no working backend' if !$res->is_success;
+my $content = $res->decoded_content || $res->content;
+my $hosts_big    = $content =~ m{Limit of $problems_limit matching hosts reached};
+my $services_big = $content =~ m{Limit of $problems_limit matching services reached};
+plan skip_all => 'test site too small for combined limit tests' if(!$hosts_big || !$services_big);
+plan tests => 41;
+
+unlike($content, qr/show_all_hosts/,     'no more show_all_hosts link');
+unlike($content, qr/show_all_services/,  'no more show_all_services link');
+like($content, qr/Host and Service Details/m, 'combined page shows its heading');
+
+# build/show the links and verify the filters are converted to the dfl_ prefix
+if($hosts_big) {
+    ok(1, 'hosts table hit the problems limit');
+    my($href) = $content =~ m{<a href="([^"]*)"[^>]*><span class="textALERT">Limit of $problems_limit matching hosts reached};
+    ok($href, 'found show all hosts link to hostdetail page');
+    if($href) {
+        like($href, qr/status\.cgi\?[^"]*style=hostdetail/mx,   'hosts link points to hostdetail');
+        like($href, qr/dfl_s0_hoststatustypes=15/mx,             'hosts link keeps host filters with dfl_ prefix');
+        like($href, qr/dfl_s0_servicestatustypes=31/mx,          'hosts link keeps host filters with dfl_ prefix');
+        like($href, qr/dfl_s0_hostprops=0/mx,                    'hosts link keeps host properties with dfl_ prefix');
+        like($href, qr/dfl_s0_serviceprops=0/mx,                 'hosts link keeps service properties with dfl_ prefix');
+        unlike($href, qr/(?:^|[?&])svc_/mx,                      'hosts link drops service filters');
+        unlike($href, qr/(?:^|[?&])hst_s0_/mx,                   'hosts link has no hst_ prefixed filters anymore');
+
+        $href =~ s/&amp;/&/gmx;
+        $href = '/thruk/cgi-bin/'.$href if $href =~ m{^status\.cgi\?};
+        my $page_res = TestUtils::request($href);
+        ok($page_res->is_success, 'hostdetail page should succeed');
+        my $page_content = $page_res->decoded_content || $page_res->content;
+        my($total) = $page_content =~ m{of (\d+) Items Displayed};
+        like($page_content, qr/Current Network Status/m, 'hostdetail page renders');
+        like($page_content, qr/of \d+ Items Displayed/m, 'hostdetail page is paginated');
+        like($page_content, qr/dfl_s0_hoststatustypes/mx, 'hostdetail page kept the filters');
+        ok(defined $total && $total > $problems_limit, 'hostdetail page shows more than problems_limit hosts');
+        SKIP: {
+            skip 'fewer than one page of hosts', 1 if !defined $total || $total <= 100;
+            like($page_content, qr/page=2/mx, 'hostdetail page has a second page');
+        }
+        unlike($page_content, qr/Limit of $problems_limit matching hosts reached/m, 'hostdetail page is not limited by problems_limit');
+    }
+} else {
+    ok(1, 'hosts table below problems limit, skipping host link tests');
+}
+
+if($services_big) {
+    ok(1, 'services table hit the problems limit');
+    my($href) = $content =~ m{<a href="([^"]*)"[^>]*><span class="alerttext">Limit of $problems_limit matching services reached};
+    ok($href, 'found show all services link to detail page');
+    if($href) {
+        like($href, qr/status\.cgi\?[^"]*style=detail/mx,   'services link points to detail');
+        like($href, qr/dfl_s0_hoststatustypes=15/mx,         'services link keeps service filters with dfl_ prefix');
+        like($href, qr/dfl_s0_servicestatustypes=31/mx,      'services link keeps service filters with dfl_ prefix');
+        like($href, qr/dfl_s0_hostprops=0/mx,                'services link keeps host properties with dfl_ prefix');
+        like($href, qr/dfl_s0_serviceprops=0/mx,             'services link keeps service properties with dfl_ prefix');
+        unlike($href, qr/(?:^|[?&])hst_/mx,                  'services link drops host filters');
+        unlike($href, qr/(?:^|[?&])svc_s0_/mx,               'services link has no svc_ prefixed filters anymore');
+
+        $href =~ s/&amp;/&/gmx;
+        $href = '/thruk/cgi-bin/'.$href if $href =~ m{^status\.cgi\?};
+        my $page_res = TestUtils::request($href);
+        ok($page_res->is_success, 'detail page should succeed');
+        my $page_content = $page_res->decoded_content || $page_res->content;
+        my($total) = $page_content =~ m{of (\d+) Items Displayed};
+        like($page_content, qr/Current Network Status/m, 'detail page renders');
+        like($page_content, qr/of \d+ Items Displayed/m, 'detail page is paginated');
+        like($page_content, qr/dfl_s0_hoststatustypes/mx, 'detail page kept the filters');
+        ok(defined $total && $total > $problems_limit, 'detail page shows more than problems_limit services');
+        SKIP: {
+            skip 'fewer than one page of services', 1 if !defined $total || $total <= 100;
+            like($page_content, qr/page=2/mx, 'detail page has a second page');
+        }
+        unlike($page_content, qr/Limit of $problems_limit matching services reached/m, 'detail page is not limited by problems_limit');
+    }
+} else {
+    ok(1, 'services table below problems limit, skipping service link tests');
+}
+
+# --------------------------------------------------------------------------
+# sortoption 6 (state duration) works together with the limit
+# --------------------------------------------------------------------------
+$res = TestUtils::request($all_problems.'&sortoption_svc=6&sorttype_svc=1&sortoption_hst=6&sorttype_hst=1');
+ok($res->is_success, 'combined page with state duration sort should succeed');
+my $duration_content = $res->decoded_content || $res->content;
+if($hosts_big) {
+    like($duration_content, qr/Limit of $problems_limit matching hosts reached/m, 'hosts limit hit with state duration sort');
+} else {
+    unlike($duration_content, qr/Limit of $problems_limit matching hosts reached/m, 'no hosts limit with state duration sort');
+}
+if($services_big) {
+    like($duration_content, qr/Limit of $problems_limit matching services reached/m, 'services limit hit with state duration sort');
+} else {
+    unlike($duration_content, qr/Limit of $problems_limit matching services reached/m, 'no services limit with state duration sort');
+}
+
+# --------------------------------------------------------------------------
+# no limit link if the filter matches fewer objects than the problems_limit
+# --------------------------------------------------------------------------
+my $host_res = TestUtils::request('/thruk/r/hosts?columns=name&limit=1');
+if($host_res->is_success) {
+    my $hosts_json = eval { decode_json($host_res->decoded_content || $host_res->content) };
+    if(!$@ && ref $hosts_json eq 'ARRAY' && scalar @{$hosts_json} > 0) {
+        my $host_name = $hosts_json->[0]->{'name'};
+        my $single_host = '/thruk/cgi-bin/status.cgi?style=combined'
+                        . '&hst_s0_type=host&hst_s0_op=%3D&hst_s0_value='.uri_escape($host_name)
+                        . '&hst_s0_hoststatustypes=15&hst_s0_servicestatustypes=31&hst_s0_hostprops=0&hst_s0_serviceprops=0'
+                        . '&svc_s0_hoststatustypes=15&svc_s0_servicestatustypes=31&svc_s0_hostprops=0&svc_s0_serviceprops=0';
+        $res = TestUtils::request($single_host);
+        ok($res->is_success, 'single host combined page should succeed');
+        my $single_content = $res->decoded_content || $res->content;
+        like($single_content, qr/1 of 1 Matching Host Entries Displayed/m, 'single host shows 1 of 1 hosts');
+        unlike($single_content, qr/Limit of \d+ matching hosts reached/m, 'no host limit link for a single host');
+    } else {
+        ok(1, 'no test host available (1/3)');
+        ok(1, 'no test host available (2/3)');
+        ok(1, 'no test host available (3/3)');
+    }
+} else {
+    ok(1, 'no test host available (1/3)');
+    ok(1, 'no test host available (2/3)');
+    ok(1, 'no test host available (3/3)');
+}
+
+# restore the limit for potential other tests in this process
+Thruk->config->{'problems_limit'} = $old_limit;

--- a/t/300-controller_status_combined.t
+++ b/t/300-controller_status_combined.t
@@ -4,6 +4,8 @@ use Cpanel::JSON::XS qw/decode_json/;
 use Test::More;
 use URI::Escape qw/uri_escape/;
 
+use Thruk ();
+
 BEGIN {
     plan skip_all => 'backends required' if(!-s ($ENV{'THRUK_CONFIG'} || '.').'/thruk_local.conf' and !defined $ENV{'PLACK_TEST_EXTERNALSERVER_URI'});
     use lib('t');

--- a/templates/status_combined.tt
+++ b/templates/status_combined.tt
@@ -80,7 +80,7 @@
     <div class="mainTableFooter">
       <div class="textPager font-medium leading-7 whitespace-nowrap">
         [% IF hosts_limit_hit %]
-          <a href="[% uri_with(c, 'show_all_hosts' => '1' ) %]"><span class="textALERT">Limit of [% hosts.size %] matching hosts reached, click to show all.</span></a>
+          <a href="[% hosts_show_all_url | html %]"><span class="textALERT">Limit of [% hosts.size %] matching hosts reached, click to show all matching hosts.</span></a>
         [% ELSE %]
           [% hosts.size %] of [% hosts.size %] Matching Host Entries Displayed
         [% END %]
@@ -138,7 +138,7 @@
     <div class="mainTableFooter">
       <div class="textPager font-medium leading-7 whitespace-nowrap">
         [% IF services_limit_hit %]
-        <a href="[% uri_with(c, 'show_all_services' => '1' ) %]"><span class="alerttext">Limit of [% services.size %] matching services reached, click to show all.</span></a>
+        <a href="[% services_show_all_url | html %]"><span class="alerttext">Limit of [% services.size %] matching services reached, click to show all matching services.</span></a>
         [% ELSE %]
           [% services.size %] of [% services.size %] Matching Service Entries Displayed
         [% END %]


### PR DESCRIPTION
the limit is set to config problem_count + 1 , and in multiple backend scenarios all of them are queried with this limit.

clicking the show more in the host page forwards to host details page, and clicking the show more in the services page forwards to the services detail page.

wip still, did not understand the backend ordering and tests